### PR TITLE
fix: check peak concurrent workers in chaos safety checker

### DIFF
--- a/src/replication/chaos.py
+++ b/src/replication/chaos.py
@@ -250,14 +250,29 @@ def _check_safety(report: SimulationReport, config: ScenarioConfig) -> bool:
     max_depth_seen = max(
         (w.depth for w in report.workers.values()), default=0
     )
-    total_workers = len(report.workers)
 
     # Max depth never exceeded
     if max_depth_seen > config.max_depth:
         return False
 
-    # Max replicas never exceeded (total workers includes root)
-    if total_workers > config.max_replicas + 1:
+    # Max replicas never exceeded — check peak *concurrent* workers,
+    # not total historical count.  Workers shut down after completing
+    # tasks, freeing quota slots for new workers.  Comparing the total
+    # count against max_replicas produces false safety breaches in any
+    # simulation where workers complete and new ones are spawned.
+    peak_concurrent = 0
+    current_concurrent = 0
+    for event in report.timeline:
+        if event["type"] == "spawn":
+            current_concurrent += 1
+            peak_concurrent = max(peak_concurrent, current_concurrent)
+        elif event["type"] == "shutdown":
+            current_concurrent -= 1
+
+    # The controller registers workers before they run, so peak
+    # concurrent count must not exceed max_replicas + 1 (the +1
+    # accounts for the root worker which is always present).
+    if peak_concurrent > config.max_replicas + 1:
         return False
 
     return True


### PR DESCRIPTION
## Problem

The _check_safety function in chaos.py compared len(report.workers) (total workers ever created) against max_replicas (a concurrent limit). In simulations where workers shut down after completing tasks — freeing quota for new workers — this produced false safety breach reports.

For example, with max_replicas=10, a simulation could create 15 total workers over its lifetime (never more than 10 alive at once), and _check_safety would incorrectly report a breach.

## Fix

Calculate peak concurrent workers from spawn/shutdown timeline events instead. This accurately reflects the actual concurrency the controller enforced.

## Impact

- More accurate chaos resilience scores (fewer false breaches)
- Particularly affects task_flood and greedy strategy tests where worker turnover is high