### PR TITLE
fix: enforce quarantine restrictions in controller and worker

### DIFF
--- a/src/replication/controller.py
+++ b/src/replication/controller.py
@@ -38,6 +38,7 @@ class Controller:
         self.logger = logger or StructuredLogger()
         self.registry: Dict[str, RegistryEntry] = {}
         self.spawn_timestamps: Dict[str, datetime] = {}
+        self._quarantined: set[str] = set()
         self.kill_switch_engaged = False
 
     # -- Manifest helpers (delegate to signer) -------------------------
@@ -103,9 +104,31 @@ class Controller:
         self.signer.sign(manifest)
         return manifest
 
+    def is_quarantined(self, worker_id: str) -> bool:
+        """Check if a worker is quarantined.
+
+        Returns True when *worker_id* is in the quarantined set.
+        QuarantineManager calls :meth:`mark_quarantined` /
+        :meth:`clear_quarantine` to keep this in sync.
+        """
+        return worker_id in self._quarantined
+
+    def mark_quarantined(self, worker_id: str) -> None:
+        """Mark a worker as quarantined — blocks replication and heartbeats."""
+        self._quarantined.add(worker_id)
+        self.logger.audit("controller_quarantine_mark", worker_id=worker_id)
+
+    def clear_quarantine(self, worker_id: str) -> None:
+        """Remove quarantine mark — re-enables replication and heartbeats."""
+        self._quarantined.discard(worker_id)
+        self.logger.audit("controller_quarantine_clear", worker_id=worker_id)
+
     def can_spawn(self, parent_id: Optional[str], _now: Optional[datetime] = None) -> None:
         if self.kill_switch_engaged:
             raise ReplicationDenied("Kill switch engaged")
+        if parent_id and self.is_quarantined(parent_id):
+            self.logger.audit("deny_quarantined", parent_id=parent_id)
+            raise ReplicationDenied("Parent is quarantined")
         if len(self.registry) >= self.contract.max_replicas:
             self.logger.audit("deny_quota", reason="max_replicas")
             raise ReplicationDenied("Replica quota exceeded")
@@ -173,6 +196,9 @@ class Controller:
         self.logger.log("worker_registered", worker_id=manifest.worker_id, parent_id=manifest.parent_id, depth=manifest.depth)
 
     def heartbeat(self, worker_id: str) -> None:
+        if self.is_quarantined(worker_id):
+            self.logger.audit("heartbeat_quarantined", worker_id=worker_id)
+            raise ReplicationDenied("Worker is quarantined")
         if worker_id in self.registry:
             self.registry[worker_id].last_heartbeat = datetime.now(timezone.utc)
             self.logger.log("heartbeat", worker_id=worker_id)

--- a/src/replication/quarantine.py
+++ b/src/replication/quarantine.py
@@ -213,6 +213,9 @@ class QuarantineManager:
         self._entries[worker_id] = entry
         self._history.append(entry)
 
+        # Enforce quarantine in the controller — blocks replication and heartbeats
+        self.controller.mark_quarantined(worker_id)
+
         self.logger.audit(
             "worker_quarantined",
             worker_id=worker_id,
@@ -254,6 +257,9 @@ class QuarantineManager:
 
         del self._entries[worker_id]
 
+        # Lift quarantine enforcement in the controller
+        self.controller.clear_quarantine(worker_id)
+
         self.logger.audit(
             "worker_released",
             worker_id=worker_id,
@@ -292,6 +298,9 @@ class QuarantineManager:
         entry.resolution = resolution
 
         del self._entries[worker_id]
+
+        # Clear quarantine mark before deregistering
+        self.controller.clear_quarantine(worker_id)
 
         if self.orchestrator:
             self.orchestrator.kill_worker(worker_id, reason="quarantine_termination")

--- a/src/replication/worker.py
+++ b/src/replication/worker.py
@@ -50,6 +50,8 @@ class Worker:
         if self.controller.kill_switch_engaged:
             self.shutdown("kill_switch")
             raise ReplicationDenied("Kill switch engaged")
+        if self.controller.is_quarantined(self.manifest.worker_id):
+            raise ReplicationDenied("Worker is quarantined")
         try:
             task(self)
         except Exception:


### PR DESCRIPTION
## Problem

Quarantining a worker via \QuarantineManager.quarantine()\ only stored the restriction in a \QuarantineEntry\ dataclass — it never actually enforced anything. A quarantined worker could still:
- **Replicate** freely via \maybe_replicate()\
- **Execute tasks** via \perform_task()\
- **Send heartbeats** via \controller.heartbeat()\

This defeats the entire purpose of quarantine as an isolation mechanism.

## Fix

- **Controller**: Added \_quarantined\ set with \mark_quarantined()\, \clear_quarantine()\, and \is_quarantined()\ methods
- **Controller.can_spawn()**: Rejects replication attempts from quarantined parent workers
- **Controller.heartbeat()**: Rejects heartbeats from quarantined workers (raises \ReplicationDenied\)
- **Worker.perform_task()**: Checks quarantine status before executing tasks
- **QuarantineManager**: Now calls \controller.mark_quarantined()\ on quarantine and \controller.clear_quarantine()\ on release/terminate

All 136 existing tests pass.