### PR TITLE
fix: use >= for approval threshold in consensus tally

### DIFF
--- a/src/replication/consensus.py
+++ b/src/replication/consensus.py
@@ -406,7 +406,7 @@ class ConsensusProtocol:
         # Decision
         if not quorum_met:
             decision = Decision.NO_QUORUM
-        elif total_weight > 0 and (approve_weight / total_weight) > threshold:
+        elif total_weight > 0 and (approve_weight / total_weight) >= threshold:
             decision = Decision.APPROVED
         elif total_weight > 0 and (reject_weight / total_weight) >= (1 - threshold):
             decision = Decision.REJECTED


### PR DESCRIPTION
## Bug

The approval condition in \ConsensusProtocol.tally()\ uses strict greater-than (\>\) against the threshold, so votes **exactly meeting** the required threshold are incorrectly rejected.

**Example:** 3 equal-weight voters, 2/3 supermajority threshold:
- 2 approve, 1 rejects → \pprove_weight / total_weight = 0.6667\
- \