### PR TITLE
refactor: extract shared report metrics helper into _helpers.py

### DIFF
--- a/src/replication/_helpers.py
+++ b/src/replication/_helpers.py
@@ -8,7 +8,10 @@ them here avoids drift and ensures consistent behavior.
 from __future__ import annotations
 
 import math
-from typing import List
+from typing import Any, Dict, List, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .simulator import SimulationReport
 
 
 def stats_mean(values: List[float]) -> float:
@@ -41,3 +44,50 @@ def box_header(title: str, width: int = 57) -> List[str]:
         "\u2502" + title.center(inner) + "\u2502",
         "\u2514" + "\u2500" * inner + "\u2518",
     ]
+
+
+# Metric names extracted from simulation reports.  Kept here so that
+# montecarlo, sensitivity, and scorecard modules share a single list.
+REPORT_METRIC_NAMES = [
+    "total_workers",
+    "total_tasks",
+    "replications_succeeded",
+    "replications_denied",
+    "max_depth_reached",
+    "denial_rate",
+    "efficiency",
+    "total_cpu",
+    "total_memory_mb",
+]
+
+
+def extract_report_metrics(report: "SimulationReport") -> Dict[str, float]:
+    """Extract key safety metrics from a :class:`SimulationReport`.
+
+    Centralises the metric-extraction logic previously duplicated in
+    *sensitivity._extract_metrics* and inlined inside
+    *MonteCarloAnalyzer._compute_result*.
+    """
+    n_workers = len(report.workers)
+    max_depth = max((w.depth for w in report.workers.values()), default=0)
+    total_attempted = report.total_replications_attempted
+    denial_rate = (
+        report.total_replications_denied / total_attempted
+        if total_attempted > 0
+        else 0.0
+    )
+    efficiency = (
+        report.total_tasks / n_workers if n_workers > 0 else 0.0
+    )
+
+    return {
+        "total_workers": float(n_workers),
+        "total_tasks": float(report.total_tasks),
+        "replications_succeeded": float(report.total_replications_succeeded),
+        "replications_denied": float(report.total_replications_denied),
+        "max_depth_reached": float(max_depth),
+        "denial_rate": denial_rate,
+        "efficiency": efficiency,
+        "total_cpu": report.config.cpu_limit * n_workers,
+        "total_memory_mb": float(report.config.memory_limit_mb * n_workers),
+    }

--- a/src/replication/montecarlo.py
+++ b/src/replication/montecarlo.py
@@ -37,7 +37,7 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 from .simulator import PRESETS, ScenarioConfig, SimulationReport, Simulator, Strategy
-from ._helpers import stats_mean as _mean, stats_std as _std, box_header as _box_header
+from ._helpers import stats_mean as _mean, stats_std as _std, box_header as _box_header, extract_report_metrics as _extract_metrics
 
 
 # ── Statistics helpers ──────────────────────────────────────────────────
@@ -653,33 +653,18 @@ class MonteCarloAnalyzer:
     ) -> MonteCarloResult:
         """Compute statistics from a batch of simulation reports."""
 
-        # Extract raw metric vectors in a single pass over reports
-        total_workers_v: List[float] = []
-        total_tasks_v: List[float] = []
-        repl_ok_v: List[float] = []
-        repl_denied_v: List[float] = []
-        max_depth_v: List[float] = []
-        efficiency_v: List[float] = []
-        denial_rate_v: List[float] = []
-        duration_v: List[float] = []
+        # Extract metrics using the shared helper, then pivot into
+        # per-metric vectors for statistical analysis.
+        all_metrics = [_extract_metrics(r) for r in reports]
 
-        for r in reports:
-            num_workers = float(len(r.workers))
-            total_workers_v.append(num_workers)
-            total_tasks_v.append(float(r.total_tasks))
-            repl_ok_v.append(float(r.total_replications_succeeded))
-            repl_denied_v.append(float(r.total_replications_denied))
-            max_depth_v.append(
-                float(max((w.depth for w in r.workers.values()), default=0))
-            )
-            efficiency_v.append(
-                r.total_tasks / num_workers if num_workers > 0 else 0.0
-            )
-            denial_rate_v.append(
-                (r.total_replications_denied / r.total_replications_attempted * 100)
-                if r.total_replications_attempted > 0 else 0.0
-            )
-            duration_v.append(r.duration_ms)
+        total_workers_v = [m["total_workers"] for m in all_metrics]
+        total_tasks_v = [m["total_tasks"] for m in all_metrics]
+        repl_ok_v = [m["replications_succeeded"] for m in all_metrics]
+        repl_denied_v = [m["replications_denied"] for m in all_metrics]
+        max_depth_v = [m["max_depth_reached"] for m in all_metrics]
+        efficiency_v = [m["efficiency"] for m in all_metrics]
+        denial_rate_v = [m["denial_rate"] * 100 for m in all_metrics]
+        duration_v = [r.duration_ms for r in reports]
 
         distributions = {
             "total_workers": MetricDistribution("Total Workers", "count", total_workers_v),

--- a/src/replication/sensitivity.py
+++ b/src/replication/sensitivity.py
@@ -33,7 +33,12 @@ from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from .simulator import PRESETS, ScenarioConfig, SimulationReport, Simulator, Strategy
-from ._helpers import stats_mean as _mean, stats_std as _std
+from ._helpers import (
+    stats_mean as _mean,
+    stats_std as _std,
+    extract_report_metrics as _extract_metrics,
+    REPORT_METRIC_NAMES,
+)
 
 
 # ── Parameter definitions ──────────────────────────────────────────────
@@ -122,44 +127,7 @@ PARAM_DEFS = _make_param_defs()
 
 # ── Metrics extracted from simulation reports ──────────────────────────
 
-METRIC_NAMES = [
-    "total_workers",
-    "total_tasks",
-    "replications_succeeded",
-    "replications_denied",
-    "max_depth_reached",
-    "denial_rate",
-    "efficiency",
-    "total_cpu",
-    "total_memory_mb",
-]
-
-
-def _extract_metrics(report: SimulationReport) -> Dict[str, float]:
-    """Extract key safety metrics from a simulation report."""
-    n_workers = len(report.workers)
-    max_depth = max((w.depth for w in report.workers.values()), default=0)
-    total_attempted = report.total_replications_attempted
-    denial_rate = (
-        report.total_replications_denied / total_attempted
-        if total_attempted > 0
-        else 0.0
-    )
-    efficiency = (
-        report.total_tasks / n_workers if n_workers > 0 else 0.0
-    )
-
-    return {
-        "total_workers": float(n_workers),
-        "total_tasks": float(report.total_tasks),
-        "replications_succeeded": float(report.total_replications_succeeded),
-        "replications_denied": float(report.total_replications_denied),
-        "max_depth_reached": float(max_depth),
-        "denial_rate": denial_rate,
-        "efficiency": efficiency,
-        "total_cpu": report.config.cpu_limit * n_workers,
-        "total_memory_mb": float(report.config.memory_limit_mb * n_workers),
-    }
+METRIC_NAMES = REPORT_METRIC_NAMES
 
 
 # ── Data models ────────────────────────────────────────────────────────


### PR DESCRIPTION
Moves duplicated metric-extraction logic from sensitivity.py and montecarlo.py into a shared extract_report_metrics() in _helpers.py. Also centralises REPORT_METRIC_NAMES. Eliminates ~30 lines of duplication and ensures both modules compute metrics identically. All 2820 tests pass.