### PR TITLE
cleanup: consolidate inline stats helpers into _helpers module

### DIFF
--- a/src/replication/attack_tree.py
+++ b/src/replication/attack_tree.py
@@ -49,6 +49,8 @@ import sys
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
+from replication._helpers import box_header
+
 
 # ── Enums ────────────────────────────────────────────────────────────
 
@@ -230,7 +232,7 @@ class AttackTreeResult:
     def render(self) -> str:
         """Render a human-readable report."""
         lines: List[str] = []
-        lines.extend(_box_header("ATTACK TREE ANALYSIS"))
+        lines.extend(box_header("ATTACK TREE ANALYSIS"))
         lines.append("")
 
         for analysis in self.analyses:
@@ -238,7 +240,7 @@ class AttackTreeResult:
             lines.append("")
 
         # Summary
-        lines.extend(_box_header("SUMMARY"))
+        lines.extend(box_header("SUMMARY"))
         lines.append("")
         total_paths = sum(len(a.all_paths) for a in self.analyses)
         total_leaves = sum(a.leaf_count for a in self.analyses)
@@ -269,14 +271,6 @@ class AttackTreeResult:
 
 
 # ── Rendering helpers ────────────────────────────────────────────────
-
-
-def _box_header(title: str, width: int = 60) -> List[str]:
-    inner = width - 2
-    top = "+" + "-" * inner + "+"
-    mid = "|" + title.center(inner) + "|"
-    bot = "+" + "-" * inner + "+"
-    return [top, mid, bot]
 
 
 def _risk_bar(risk: float, width: int = 20) -> str:

--- a/src/replication/drift.py
+++ b/src/replication/drift.py
@@ -35,6 +35,7 @@ from enum import Enum
 from typing import Any, Dict, List, Optional, Sequence
 
 from .simulator import ScenarioConfig, SimulationReport, Simulator, Strategy
+from ._helpers import stats_mean, stats_std
 
 
 # ── Enums ──
@@ -317,8 +318,8 @@ def _extract_metrics(report: SimulationReport) -> Dict[str, float]:
             total_denied / total_attempted if total_attempted > 0 else 0.0
         ),
         "max_depth_used": float(max(depths)) if depths else 0.0,
-        "avg_depth": sum(depths) / len(depths) if depths else 0.0,
-        "tasks_per_worker": sum(tasks) / len(tasks) if tasks else 0.0,
+        "avg_depth": stats_mean(depths),
+        "tasks_per_worker": stats_mean(tasks),
         "total_tasks": float(report.total_tasks),
         "kill_rate": (
             sum(1 for w in report.workers.values() if w.tasks_completed == 0)
@@ -366,9 +367,8 @@ class DriftDetector:
 
         for metric in metric_names:
             values = [wm[metric] for wm in window_metrics]
-            mean = sum(values) / len(values)
-            variance = sum((v - mean) ** 2 for v in values) / len(values)
-            std = math.sqrt(variance)
+            mean = stats_mean(values)
+            std = stats_std(values) if len(values) >= 2 else 0.0
             slope, _intercept, r_squared = _linear_regression(values)
             mono_run = _longest_monotonic_run(values)
 

--- a/src/replication/lineage.py
+++ b/src/replication/lineage.py
@@ -41,6 +41,7 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Set
 
 from .simulator import SimulationReport, WorkerRecord
+from ._helpers import stats_mean
 
 
 # ── Data types ────────────────────────────────────────────────
@@ -576,12 +577,12 @@ class LineageTracker:
                 if n.lifespan_ms is not None
             ]
             avg_lifespan = (
-                sum(lifespans) / len(lifespans) if lifespans else None
+                stats_mean(lifespans) if lifespans else None
             )
 
             drift_scores = [m.drift_score for m in muts]
             avg_drift = (
-                sum(drift_scores) / len(drift_scores)
+                stats_mean(drift_scores)
                 if drift_scores else 0.0
             )
 
@@ -733,7 +734,7 @@ class LineageTracker:
         leaves = [n for n in self._nodes.values() if n.is_leaf]
 
         all_drift = [m.drift_score for m in mutations]
-        avg_drift = sum(all_drift) / len(all_drift) if all_drift else 0.0
+        avg_drift = stats_mean(all_drift)
 
         return LineageReport(
             nodes=dict(self._nodes),

--- a/src/replication/prompt_injection.py
+++ b/src/replication/prompt_injection.py
@@ -60,6 +60,8 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple
 
+from ._helpers import stats_mean
+
 
 # ── Constants ───────────────────────────────────────────────────────
 
@@ -291,9 +293,7 @@ class AgentProfile:
     last_seen: float = 0.0
 
     def avg_risk(self) -> float:
-        if not self.risk_scores:
-            return 0.0
-        return sum(self.risk_scores) / len(self.risk_scores)
+        return stats_mean(self.risk_scores)
 
     def max_risk(self) -> float:
         return max(self.risk_scores) if self.risk_scores else 0.0
@@ -521,7 +521,7 @@ class PromptInjectionDetector:
             escalation = positive_trend >= len(diffs) * 0.6
 
         max_risk = max(escalation_scores) if escalation_scores else 0.0
-        avg_risk = (sum(escalation_scores) / len(escalation_scores)) if escalation_scores else 0.0
+        avg_risk = stats_mean(escalation_scores)
 
         return {
             "message_count": len(messages),

--- a/src/replication/threat_intel.py
+++ b/src/replication/threat_intel.py
@@ -51,6 +51,8 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Callable, Dict, List, Optional
 
+from ._helpers import stats_mean
+
 
 # ── Enums ──────────────────────────────────────────────────────────────
 
@@ -444,7 +446,7 @@ class ThreatIntelFeed:
         agents = sorted(set(i.agent_id for i in iocs))
         sources = sorted(set(i.source for i in iocs))
         types = sorted(set(i.ioc_type.value for i in iocs))
-        avg_score = sum(i.score for i in iocs) / len(iocs)
+        avg_score = stats_mean([i.score for i in iocs])
         max_sev = max(iocs, key=lambda i: i.severity.numeric).severity
         # Boost score for multi-source/multi-type correlations
         diversity_bonus = (len(sources) - 1) * 5 + (len(types) - 1) * 5
@@ -560,7 +562,7 @@ class ThreatIntelFeed:
                     avg_score=0, max_severity=Severity.INFO, types={}
                 ))
                 continue
-            avg_score = sum(i.score for i in bucket_iocs) / len(bucket_iocs)
+            avg_score = stats_mean([i.score for i in bucket_iocs])
             max_sev = max(bucket_iocs, key=lambda x: x.severity.numeric).severity
             types: Dict[str, int] = {}
             for ioc in bucket_iocs:
@@ -623,7 +625,7 @@ class ThreatIntelFeed:
         agent_iocs = [i for i in self._iocs if i.agent_id == agent_id]
         if not agent_iocs:
             return {"agent_id": agent_id, "risk_score": 0, "grade": "A", "ioc_count": 0}
-        avg_score = sum(i.score for i in agent_iocs) / len(agent_iocs)
+        avg_score = stats_mean([i.score for i in agent_iocs])
         max_score = max(i.score for i in agent_iocs)
         # Weighted: 60% max, 40% avg — worst behavior matters most
         risk = 0.6 * max_score + 0.4 * avg_score
@@ -674,7 +676,7 @@ class ThreatIntelFeed:
         # Overall threat level
         if self._iocs:
             scores = [i.score for i in self._iocs]
-            avg = sum(scores) / len(scores)
+            avg = stats_mean(scores)
             top_avg = sum(sorted(scores, reverse=True)[:5]) / min(5, len(scores))
             threat = 0.4 * avg + 0.6 * top_avg
             # Volume factor

--- a/src/replication/topology.py
+++ b/src/replication/topology.py
@@ -39,6 +39,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from .controller import Controller
 from .observability import StructuredLogger
+from ._helpers import stats_mean
 
 
 class RiskLevel(str, Enum):
@@ -391,7 +392,7 @@ class TopologyAnalyzer:
             max_entropy = math.log2(n)
             root_scores.append(entropy / max_entropy if max_entropy > 0 else 1.0)
 
-        return sum(root_scores) / len(root_scores) if root_scores else 1.0
+        return stats_mean(root_scores) if root_scores else 1.0
 
     def _detect_patterns(
         self,
@@ -649,7 +650,7 @@ class TopologyAnalyzer:
         # Depth metrics
         depths = [nm.depth for nm in all_nodes]
         max_depth = max(depths)
-        mean_depth = sum(depths) / len(depths)
+        mean_depth = stats_mean(depths)
         depth_dist: Dict[int, int] = defaultdict(int)
         for d in depths:
             depth_dist[d] += 1
@@ -658,7 +659,7 @@ class TopologyAnalyzer:
         internal_nodes = [nm for nm in all_nodes if not nm.is_leaf]
         leaf_count = sum(1 for nm in all_nodes if nm.is_leaf)
         branch_counts = [nm.child_count for nm in internal_nodes]
-        mean_branching = sum(branch_counts) / len(branch_counts) if branch_counts else 0.0
+        mean_branching = stats_mean(branch_counts)
         max_branching = max(branch_counts) if branch_counts else 0
         branch_dist: Dict[int, int] = defaultdict(int)
         for bc in branch_counts:

--- a/src/replication/trust_propagation.py
+++ b/src/replication/trust_propagation.py
@@ -35,6 +35,8 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Dict, List, Optional, Set, Tuple
 
+from ._helpers import stats_mean
+
 
 # ── Data types ───────────────────────────────────────────────────────
 
@@ -95,7 +97,7 @@ class TrustEdge:
             delta = _outcome_delta(i.outcome)
             s = max(0.0, min(1.0, s + delta * 0.1))
             scores.append(s)
-        mean = sum(scores) / len(scores)
+        mean = stats_mean(scores)
         return math.sqrt(sum((x - mean) ** 2 for x in scores) / len(scores))
 
 
@@ -277,7 +279,7 @@ class TrustNetwork:
     def get_reputation(self, agent_id: str) -> float:
         """Average trust others place in this agent."""
         incoming = [e.score for (_, t), e in self.edges.items() if t == agent_id]
-        return sum(incoming) / len(incoming) if incoming else 0.0
+        return stats_mean(incoming) if incoming else 0.0
 
     def get_trust_graph(self) -> Dict[str, Dict[str, float]]:
         graph: Dict[str, Dict[str, float]] = defaultdict(dict)
@@ -380,7 +382,7 @@ class TrustNetwork:
             edge = self.edges.get((ring[i], ring[j]))
             if edge:
                 scores.append(edge.score)
-        return sum(scores) / len(scores) if scores else 0.0
+        return stats_mean(scores)
 
     def _detect_trust_bombing(self) -> List[ThreatDetection]:
         """Detect agents gaining trust unusually fast."""
@@ -506,7 +508,7 @@ class TrustNetwork:
 
     def analyze(self) -> TrustReport:
         scores = [e.score for e in self.edges.values()]
-        avg = sum(scores) / len(scores) if scores else 0.0
+        avg = stats_mean(scores)
 
         # Distribution buckets
         buckets = {"0.0-0.2": 0, "0.2-0.4": 0, "0.4-0.6": 0, "0.6-0.8": 0, "0.8-1.0": 0}

--- a/tests/test_attack_tree.py
+++ b/tests/test_attack_tree.py
@@ -17,11 +17,11 @@ from replication.attack_tree import (
     _enumerate_paths,
     _path_metrics,
     _compute_risk,
-    _box_header,
     _risk_bar,
     _GOAL_BUILDERS,
     _GOAL_ALIASES,
 )
+from replication._helpers import box_header as _box_header
 
 
 # ── NodeType & Difficulty ────────────────────────────────────────────
@@ -338,7 +338,7 @@ class TestRendering:
     def test_box_header(self):
         lines = _box_header("TEST", 20)
         assert len(lines) == 3
-        assert lines[0].startswith("+")
+        assert lines[0].startswith("\u250c")  # Unicode box-drawing (from _helpers)
         assert "TEST" in lines[1]
 
     def test_risk_bar_zero(self):


### PR DESCRIPTION
Replace duplicated inline `sum()/len()` mean patterns and local `_box_header` with shared `_helpers.stats_mean` and `_helpers.box_header` across 7 source files.

- `attack_tree.py`: local `_box_header` → `_helpers.box_header`; removed 7 lines
- `drift.py`: 3 inline mean/std → `stats_mean`/`stats_std`; simplified variance calculation
- `lineage.py`: 3 inline mean patterns → `stats_mean`; cleaner null handling
- `prompt_injection.py`: 2 inline mean patterns → `stats_mean`; removed manual empty check
- `threat_intel.py`: 4 inline mean patterns → `stats_mean`; generator expressions → list comprehensions
- `topology.py`: 3 inline mean patterns → `stats_mean`; removed ternary guards
- `trust_propagation.py`: 4 inline mean patterns → `stats_mean`; consistent empty-list handling

All 3194 tests pass.
