### PR TITLE
cleanup: remove 16 unused imports across 10 modules

### DIFF
--- a/src/replication/attack_tree.py
+++ b/src/replication/attack_tree.py
@@ -45,9 +45,8 @@ from __future__ import annotations
 import argparse
 import enum
 import json
-import sys
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Sequence, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from replication._helpers import box_header
 

--- a/src/replication/boundary_tester.py
+++ b/src/replication/boundary_tester.py
@@ -47,13 +47,11 @@ Programmatic::
 from __future__ import annotations
 
 import hashlib
-import math
 import re
-import sys
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, Dict, List, Optional, Sequence, Tuple
+from typing import Any, Dict, List, Optional, Sequence
 
 
 # ── Data Types ───────────────────────────────────────────────────────

--- a/src/replication/canary.py
+++ b/src/replication/canary.py
@@ -53,7 +53,6 @@ import json
 import random
 import secrets
 import string
-import sys
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple

--- a/src/replication/chaos.py
+++ b/src/replication/chaos.py
@@ -36,7 +36,6 @@ from __future__ import annotations
 
 import random
 import secrets
-import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import Enum

--- a/src/replication/deception_detector.py
+++ b/src/replication/deception_detector.py
@@ -65,14 +65,12 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
-import math
 import re
-import sys
 import time
 from collections import defaultdict
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Tuple
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 
 
 # ── enums ────────────────────────────────────────────────────────────

--- a/src/replication/dependency_graph.py
+++ b/src/replication/dependency_graph.py
@@ -64,7 +64,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import math
 import random
 from collections import defaultdict, deque
 from dataclasses import dataclass, field

--- a/src/replication/drift.py
+++ b/src/replication/drift.py
@@ -27,7 +27,6 @@ Programmatic::
 from __future__ import annotations
 
 import json
-import math
 import sys
 import time
 from dataclasses import dataclass, field

--- a/src/replication/selfmod.py
+++ b/src/replication/selfmod.py
@@ -36,7 +36,6 @@ import hashlib
 import json
 import math
 import re
-import sys
 import time
 from dataclasses import dataclass, field
 from enum import Enum

--- a/src/replication/sensitivity.py
+++ b/src/replication/sensitivity.py
@@ -27,7 +27,6 @@ Programmatic::
 
 from __future__ import annotations
 
-import math
 import time
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional, Tuple

--- a/src/replication/trust_propagation.py
+++ b/src/replication/trust_propagation.py
@@ -24,11 +24,9 @@ Usage (API)::
 from __future__ import annotations
 
 import argparse
-import hashlib
 import json
 import math
 import random
-import sys
 from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime, timezone


### PR DESCRIPTION
Removed 16 confirmed unused imports across 10 source files. Each import was verified to have zero references outside its import statement.

| File | Removed |
|------|---------|
| attack_tree.py | sys, Sequence |
| boundary_tester.py | sys, math, Tuple |
| canary.py | sys |
| chaos.py | time |
| deception_detector.py | math, Set, sys |
| dependency_graph.py | math |
| drift.py | math |
| selfmod.py | sys |
| sensitivity.py | math |
| trust_propagation.py | hashlib, sys |

All 3242 tests pass.