### PR TITLE
fix: log unknown worker kills + refactor consensus math import

### DIFF
--- a/src/replication/consensus.py
+++ b/src/replication/consensus.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 import time
 from dataclasses import dataclass, field
 from enum import Enum
@@ -649,7 +650,6 @@ class ConsensusProtocol:
 
     def _quorum_count(self) -> int:
         """Minimum number of non-abstain votes for quorum."""
-        import math
         return max(1, math.ceil(self.voter_count * self._config.quorum_fraction))
 
     def _get_open_proposal(self, proposal_id: str) -> Proposal:

--- a/src/replication/orchestrator.py
+++ b/src/replication/orchestrator.py
@@ -45,6 +45,12 @@ class SandboxOrchestrator:
         record = self.containers.pop(worker_id, None)
         if record:
             self.logger.log("container_killed", worker_id=worker_id, reason=reason)
+        else:
+            self.logger.log(
+                "container_kill_skipped",
+                worker_id=worker_id,
+                reason=f"unknown worker (kill reason: {reason})",
+            )
 
     def kill_all(self, reason: str) -> None:
         for worker_id in list(self.containers.keys()):


### PR DESCRIPTION
## Changes

### Bug Fix: orchestrator.py
- \kill_worker()\ now logs a warning when called with an unknown \worker_id\ instead of silently doing nothing
- Prevents silent failures during \kill_all()\ and improves debuggability

### Refactor: consensus.py  
- Moved \import math\ from inside \_quorum_count()\ to module-level imports
- Local imports add overhead on every call and obscure dependencies

*Automated gardener run — 2026-03-09*