### PR TITLE
fix: use dynamic severity in eclipse threat detection

### DIFF
--- a/src/replication/trust_propagation.py
+++ b/src/replication/trust_propagation.py
@@ -441,12 +441,13 @@ class TrustNetwork:
             top_score = max(s for _, s in incoming)
             if total > 0 and top_score / total > 0.5:
                 dominant = max(incoming, key=lambda x: x[1])[0]
+                confidence = round(top_score / total, 2)
                 detections.append(ThreatDetection(
                     threat_type=ThreatType.ECLIPSE,
-                    severity="high",
+                    severity=_severity(confidence),
                     agents_involved=[aid, dominant],
                     evidence=f"{dominant} controls {top_score / total:.0%} of {aid}'s incoming trust",
-                    confidence=round(top_score / total, 2),
+                    confidence=confidence,
                     recommendation=f"Diversify trust sources for {aid}; single point of trust failure",
                 ))
         return detections


### PR DESCRIPTION
## Bug

\_detect_eclipse\ in \	rust_propagation.py\ hardcoded \severity='high'\ for all eclipse attacks, regardless of actual dominance ratio. A 51% trust dominance got the same severity as 99%, making it impossible to triage eclipse threats by urgency.

## Fix

Replace the hardcoded \'high'\ with \_severity(confidence)\, consistent with all other threat detectors (\_detect_sybil\, \_detect_collusion\, \_detect_trust_bombing\, \_detect_sleeper\).

Now eclipse threats are classified as low/medium/high/critical based on the actual trust dominance ratio.