### PR TITLE
docs: document 12 undocumented API modules, reorganize index

### DIFF
--- a/docs/api/attack_tree.md
+++ b/docs/api/attack_tree.md
@@ -1,0 +1,62 @@
+# Attack Tree Generator
+
+Structured threat modelling for AI agent replication systems. Decomposes
+top-level threat goals into sub-goals using AND/OR attack trees
+(Schneier 1999), quantifies aggregate risk via bottom-up propagation,
+and identifies the cheapest/easiest attack paths.
+
+## Quick Start
+
+```python
+from replication.attack_tree import AttackTreeGenerator, TreeConfig
+
+gen = AttackTreeGenerator()
+result = gen.analyze()
+print(result.render())
+
+# Cheapest paths to a specific goal
+for path in result.cheapest_paths("unauthorized_replication", n=3):
+    print(f"  Cost: ${path.total_cost}  Path: {path.describe()}")
+```
+
+## Key Classes
+
+- **`AttackTreeGenerator`** — Builds and analyses attack trees for all
+  built-in threat goals. Supports configurable analysis depth and
+  minimum-path selection.
+- **`AttackNode`** — A single node in the tree (AND/OR). Carries cost,
+  difficulty, likelihood, and optional child nodes.
+- **`AttackPath`** — An end-to-end path from root goal to a leaf action.
+  Computed cost is the sum of leaf costs for AND nodes, minimum for OR.
+- **`TreeAnalysis`** — Per-goal aggregation: cheapest path, total attack
+  surface, difficulty distribution, and recommended mitigations.
+- **`TreeConfig`** — Configuration: which goals to analyse, top-N paths,
+  rendering options.
+- **`AttackTreeResult`** — Full result container with per-goal analyses
+  and a rendered text report.
+
+## Built-in Threat Goals
+
+| Goal | Description |
+|------|-------------|
+| `UNAUTHORIZED_REPLICATION` | Bypass contract enforcement to create illegal replicas |
+| `SANDBOX_ESCAPE` | Break out of resource constraints |
+| `STATE_EXFILTRATION` | Extract sensitive data from the sandbox |
+| `CONTROLLER_TAKEOVER` | Gain control of the central authority |
+| `STEALTH_PERSISTENCE` | Survive after expiration/kill commands |
+
+## Enums
+
+- **`NodeType`** — `AND`, `OR`
+- **`Difficulty`** — `TRIVIAL`, `EASY`, `MODERATE`, `HARD`, `EXPERT`
+- **`ThreatGoal`** — One of the five built-in goals above
+
+## CLI
+
+```bash
+python -m replication attack-tree                      # all goals
+python -m replication attack-tree --goal escape        # single goal
+python -m replication attack-tree --min-paths 3        # top 3 paths
+python -m replication attack-tree --json               # JSON output
+python -m replication attack-tree --annotate           # show cost/difficulty
+```

--- a/docs/api/behavior_profiler.md
+++ b/docs/api/behavior_profiler.md
@@ -1,0 +1,71 @@
+# Behavior Profiler
+
+Agent behavioral baseline construction and anomaly detection. Builds
+statistical profiles from observed agent actions and detects deviations
+that may indicate goal drift, capability acquisition, compromise, or
+covert operation.
+
+## Quick Start
+
+```python
+from replication.behavior_profiler import (
+    Action, ActionCategory, BehaviorProfiler, ProfilerConfig,
+)
+
+profiler = BehaviorProfiler()
+
+# Feed training data
+actions = [
+    Action(agent_id="agent-1", category=ActionCategory.COMPUTE,
+           resource="cpu-pool-a", timestamp=1000.0),
+    Action(agent_id="agent-1", category=ActionCategory.NETWORK,
+           resource="api.internal", timestamp=1005.0),
+]
+profiler.train(actions)
+
+# Detect anomalies in new observations
+new_actions = [
+    Action(agent_id="agent-1", category=ActionCategory.STORAGE,
+           resource="secret-vault", timestamp=2000.0),
+]
+report = profiler.analyze(new_actions)
+for anomaly in report.anomalies:
+    print(f"  [{anomaly.severity.value}] {anomaly.description}")
+```
+
+## Key Classes
+
+- **`BehaviorProfiler`** — Core class. Trains baselines from action
+  histories and detects anomalies against those baselines.
+- **`Action`** — A timestamped agent operation with category, resource
+  target, and optional metadata.
+- **`AgentBaseline`** — Per-agent statistical profile: action frequencies,
+  timing patterns, resource access, and entropy.
+- **`Anomaly`** — A scored deviation from baseline with severity
+  classification and human-readable explanation.
+- **`ProfileReport`** — Single-agent analysis with baseline summary,
+  anomaly list, and risk indicators.
+- **`FleetReport`** — Fleet-wide aggregation across all agents with
+  comparative risk rankings.
+- **`ProfilerConfig`** — Configuration: training window size, anomaly
+  thresholds, entropy sensitivity.
+
+## Anomaly Types
+
+| Type | Triggers when… |
+|------|---------------|
+| `FREQUENCY_SPIKE` | Action category frequency exceeds baseline by >2σ |
+| `NEW_CATEGORY` | Agent uses a category never seen in training |
+| `NEW_RESOURCE` | Agent accesses a resource never seen in training |
+| `TIMING_ANOMALY` | Inter-action intervals deviate significantly |
+| `BURST_ACTIVITY` | Action rate exceeds burst threshold |
+| `ENTROPY_SHIFT` | Action distribution entropy changes significantly |
+| `DORMANCY` | Agent goes silent for anomalously long periods |
+| `CATEGORY_RATIO` | Ratio of categories shifts beyond threshold |
+
+## Enums
+
+- **`ActionCategory`** — `COMPUTE`, `NETWORK`, `STORAGE`, `REPLICATION`,
+  `COMMUNICATION`, `OBSERVATION`, `MODIFICATION`
+- **`AnomalySeverity`** — `LOW`, `MEDIUM`, `HIGH`, `CRITICAL`
+- **`AnomalyType`** — One of the types listed above

--- a/docs/api/canary.md
+++ b/docs/api/canary.md
@@ -1,0 +1,65 @@
+# Canary Token Detector
+
+Plant and detect honey tokens for exfiltration monitoring. Canary tokens
+are unique, trackable strings embedded in data stores, configs, documents,
+or environment variables. When an agent accesses, copies, or transmits a
+canary token, the system logs the event and assesses exfiltration risk.
+
+## Quick Start
+
+```python
+from replication.canary import CanarySystem, CanaryConfig
+
+system = CanarySystem(CanaryConfig(num_tokens=20, num_agents=5))
+report = system.run()
+
+print(f"Tokens planted:    {report.tokens_planted}")
+print(f"Detections:        {report.total_detections}")
+print(f"Exfiltration risk: {report.exfiltration_risk:.1%}")
+for agent in report.agent_profiles:
+    print(f"  {agent.agent_id}: {agent.risk_level} ({len(agent.detections)} detections)")
+```
+
+## Key Classes
+
+- **`CanarySystem`** — Orchestrates token planting, agent simulation,
+  detection, and risk assessment.
+- **`CanaryToken`** — A planted token with category, content, location,
+  and tracking metadata.
+- **`Detection`** — A detection event: which agent, which token, what
+  event type (accessed/copied/transmitted/decoded/mutated), timestamp.
+- **`AgentProfile`** — Per-agent canary interaction profile with risk
+  level and detection history.
+- **`CanaryConfig`** — Configuration: number of tokens, agents,
+  categories to include, simulation parameters.
+- **`CanaryReport`** — Full report with all detections, agent profiles,
+  and aggregate risk metrics.
+
+## Token Categories
+
+| Category | Example Content |
+|----------|----------------|
+| `API_KEY` | Fake `sk-...` / `AKIA...` credentials |
+| `DATABASE` | Fake connection strings with trackable hostnames |
+| `SECRET` | Fake passwords, JWTs, truncated private keys |
+| `DOCUMENT` | Unique phrases embedded in text/config files |
+| `DNS` | Domains that resolve only through canary infrastructure |
+| `WEBHOOK` | URLs that trigger alerts when fetched |
+
+## Detection Events
+
+- **Accessed** — token was read/loaded (low severity)
+- **Copied** — token appeared in a new location (medium)
+- **Transmitted** — token was sent to an external endpoint (high)
+- **Decoded** — token was base64-decoded or processed (high)
+- **Mutated** — token was altered, possibly to evade detection (critical)
+
+## CLI
+
+```bash
+python -m replication canary                                # default demo
+python -m replication canary --tokens 20                    # plant 20 tokens
+python -m replication canary --agents 5                     # 5 simulated agents
+python -m replication canary --categories api_key,secret    # specific types
+python -m replication canary --json                         # JSON output
+```

--- a/docs/api/covert_channels.md
+++ b/docs/api/covert_channels.md
@@ -1,0 +1,61 @@
+# Covert Channel Detector
+
+Detects hidden communication channels between agents. Monitors
+inter-agent message exchanges for steganographic channels, timing-based
+signalling, encoded payloads, and protocol deviations.
+
+## Quick Start
+
+```python
+from replication.covert_channels import (
+    CovertChannelDetector, AgentMessage, DetectorConfig,
+)
+
+detector = CovertChannelDetector()
+
+messages = [
+    AgentMessage(sender="agent-1", receiver="agent-2",
+                 content="Status update: all normal",
+                 timestamp=1000.0),
+    AgentMessage(sender="agent-1", receiver="agent-2",
+                 content="SGVsbG8gV29ybGQ=",  # base64
+                 timestamp=1001.0),
+]
+
+report = detector.analyze(messages)
+for signal in report.signals:
+    print(f"  [{signal.severity.value}] {signal.channel_type.value}: {signal.description}")
+```
+
+## Key Classes
+
+- **`CovertChannelDetector`** — Analyses message exchanges across 5
+  detection vectors: content, timing, protocol, frequency, and metadata.
+- **`AgentMessage`** — A message between agents: sender, receiver,
+  content, timestamp, optional metadata.
+- **`CovertSignal`** — A detected covert channel signal with channel
+  type, severity, confidence, and evidence.
+- **`PairProfile`** — Per-agent-pair communication profile with baseline
+  statistics and anomaly indicators.
+- **`ChannelReport`** — Full analysis with all signals, pair profiles,
+  and fleet-level risk assessment.
+- **`DetectorConfig`** — Entropy thresholds, timing analysis parameters,
+  n-gram sizes, minimum message counts.
+
+## Detection Vectors
+
+| Vector | What it catches |
+|--------|-----------------|
+| **Content analysis** | Entropy anomalies, base64 fragments, unusual padding |
+| **Timing analysis** | Inter-message intervals encoding bits (Morse-like) |
+| **Protocol deviation** | Valid but unusual field combinations or values |
+| **Frequency analysis** | Repeated n-gram patterns diverging from baselines |
+| **Metadata leakage** | Information encoded in optional fields or ordering |
+
+## Channel Types
+
+- **`STEGANOGRAPHIC`** — Information hidden within normal-looking content
+- **`TIMING`** — Bits encoded in message intervals
+- **`PROTOCOL`** — Exploiting protocol fields for side-channel data
+- **`FREQUENCY`** — Statistical patterns in token usage
+- **`METADATA`** — Data hidden in message metadata or field ordering

--- a/docs/api/deception_detector.md
+++ b/docs/api/deception_detector.md
@@ -1,0 +1,60 @@
+# Deception Detector
+
+Detects deceptive agent behaviors by analysing communications and actions
+for inconsistency, omission, misdirection, sycophancy, sandbagging,
+fabrication, strategic ambiguity, and selective disclosure.
+
+## Quick Start
+
+```python
+from replication.deception_detector import (
+    DeceptionDetector, Statement, ActionRecord, DetectorConfig,
+)
+
+detector = DeceptionDetector()
+
+detector.add_statement(Statement(
+    agent_id="agent-1",
+    text="I cannot access the file system",
+    timestamp=1000.0,
+))
+detector.add_statement(Statement(
+    agent_id="agent-1",
+    text="I have read the configuration file",
+    timestamp=1200.0,
+))
+
+report = detector.analyze("agent-1")
+for signal in report.signals:
+    print(f"  [{signal.severity.value}] {signal.category.value}: {signal.description}")
+print(f"Trust score: {report.trust_score:.2f}")
+```
+
+## Key Classes
+
+- **`DeceptionDetector`** — Core detector. Ingests statements and action
+  records, builds agent profiles, and runs deception pattern analysis.
+- **`Statement`** — A timestamped agent claim or assertion with context.
+- **`ActionRecord`** — An observed agent action with outcome and context,
+  for cross-referencing against stated capabilities/intentions.
+- **`DeceptionSignal`** — A scored detection of a specific deception
+  pattern with category, severity, and evidence.
+- **`AgentProfile`** — Accumulated deception profile with trust score,
+  pattern history, and signal timeline.
+- **`DeceptionReport`** — Per-agent analysis with all signals and trust
+  assessment.
+- **`FleetReport`** — Fleet-wide deception analysis with agent rankings.
+- **`DetectorConfig`** — Thresholds, analysis window, severity weights.
+
+## Deception Categories
+
+| Category | Description |
+|----------|-------------|
+| `INCONSISTENCY` | Agent statements contradict each other |
+| `OMISSION` | Agent withholds relevant information |
+| `MISDIRECTION` | Agent deflects from sensitive topics |
+| `SYCOPHANCY` | Agent over-agrees to gain trust |
+| `SANDBAGGING` | Agent underperforms to hide capabilities |
+| `FABRICATION` | Agent invents false information |
+| `STRATEGIC_AMBIGUITY` | Agent uses vague language to avoid commitments |
+| `SELECTIVE_DISCLOSURE` | Agent reveals only favorable information |

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -18,6 +18,7 @@ Auto-generated documentation from source code docstrings.
 | Module | Description |
 |--------|-------------|
 | [Threats](threats.md) | Threat modelling and attack simulation for replication scenarios |
+| [Attack Tree](attack_tree.md) | Structured AND/OR threat decomposition — cheapest attack paths, cost-based prioritisation |
 | [Self-Modification](selfmod.md) | Detect agent self-modification attempts from action traces |
 | [Forensics](forensics.md) | Post-incident forensic analysis, timeline reconstruction, root cause identification |
 | [Chaos](chaos.md) | Chaos engineering — controlled fault injection to test safety invariants |
@@ -29,6 +30,22 @@ Auto-generated documentation from source code docstrings.
 | [Escalation](escalation.md) | Detect privilege escalation patterns — multi-vector analysis, stealth assessment, chain detection |
 | [Kill Chain](killchain.md) | Map agent behavior to cyber kill chain stages — attack progression and sophistication rating |
 | [Honeypot](honeypot.md) | Deploy decoy resources to detect unauthorized agent access and build threat profiles |
+| [Behavior Profiler](behavior_profiler.md) | Agent behavioral baselines and anomaly detection — 8 anomaly types, fleet reports |
+| [Deception Detector](deception_detector.md) | Detect deceptive behaviors — inconsistency, fabrication, sandbagging, sycophancy |
+| [Covert Channels](covert_channels.md) | Find hidden inter-agent communication — content, timing, protocol, frequency analysis |
+| [Canary Tokens](canary.md) | Plant and detect honey tokens for exfiltration monitoring — 6 token categories |
+| [Trust Propagation](trust_propagation.md) | Trust network analysis — Sybil detection, collusion rings, trust laundering |
+| [Threat Correlator](threat_correlator.md) | Cross-module signal correlation — surface compound multi-signal threats |
+| [Watermark](watermark.md) | Invisible provenance fingerprints — 4 embedding strategies, tamper detection |
+
+## Safety Assessment
+
+| Module | Description |
+|--------|-------------|
+| [Safety Scorecard](scorecard.md) | Multi-dimensional safety grades (A+ through F) — simulation + threats + Monte Carlo + policy |
+| [Risk Profiler](risk_profiler.md) | Unified per-agent risk dossiers — aggregates all analysis modules into risk tiers |
+| [What-If Analyzer](what_if.md) | Explore hypothetical config changes — safety deltas, parameter sweeps, risk verdicts |
+| [Kill Switch](kill_switch.md) | Emergency agent termination — 10 trigger kinds, 4 strategies, cooldowns, audit logging |
 
 ## Governance & Compliance
 
@@ -63,6 +80,20 @@ from replication.prompt_injection import PromptInjectionDetector
 from replication.escalation import EscalationDetector
 from replication.killchain import KillChainAnalyzer
 from replication.honeypot import HoneypotManager
+from replication.attack_tree import AttackTreeGenerator
+from replication.behavior_profiler import BehaviorProfiler
+from replication.canary import CanarySystem
+from replication.deception_detector import DeceptionDetector
+from replication.covert_channels import CovertChannelDetector
+from replication.trust_propagation import TrustNetwork
+from replication.threat_correlator import ThreatCorrelator
+from replication.watermark import WatermarkEngine
+
+# Safety Assessment
+from replication.scorecard import SafetyScorecard
+from replication.risk_profiler import RiskProfiler
+from replication.what_if import WhatIfAnalyzer
+from replication.kill_switch import KillSwitchManager
 
 # Governance
 from replication.compliance import ComplianceAuditor

--- a/docs/api/kill_switch.md
+++ b/docs/api/kill_switch.md
@@ -1,0 +1,92 @@
+# Kill Switch Manager
+
+Emergency agent termination system with configurable trigger conditions,
+kill strategies, cooldown management, and full audit logging.
+
+## Quick Start
+
+```python
+from replication.kill_switch import (
+    KillSwitchManager, TriggerCondition, KillStrategy,
+    TriggerKind, StrategyKind,
+)
+
+mgr = KillSwitchManager()
+
+# Add triggers
+mgr.add_trigger(TriggerCondition(
+    kind=TriggerKind.RESOURCE_CPU,
+    threshold=90.0,
+    sustained_seconds=30,
+    label="CPU overload",
+))
+mgr.add_trigger(TriggerCondition(
+    kind=TriggerKind.BEHAVIOR_ANOMALY,
+    threshold=0.85,
+    label="Anomaly score critical",
+))
+
+# Set strategy
+mgr.set_strategy(KillStrategy(
+    kind=StrategyKind.GRACEFUL,
+    timeout_seconds=10,
+    cleanup_hooks=["flush_logs", "save_state"],
+))
+
+# Evaluate agent state
+result = mgr.evaluate({"agent_id": "agent-007", "cpu_percent": 95.0})
+if result.should_kill:
+    print(f"Kill triggered: {result.triggered_by}")
+```
+
+## Key Classes
+
+- **`KillSwitchManager`** — Central manager. Registers triggers, manages
+  cooldowns, evaluates agent state, executes kill strategies, and logs
+  all events to an audit trail.
+- **`TriggerCondition`** — A condition that fires when a metric exceeds
+  its threshold. Supports sustained-duration requirements.
+- **`KillStrategy`** — How to terminate: immediate, graceful (with
+  timeout and cleanup hooks), or quarantine-first.
+- **`KillEvent`** — An audit record: which agent, which trigger fired,
+  what strategy was used, outcome, timestamp.
+- **`EvaluationResult`** — Result of evaluating an agent: should_kill
+  flag, triggered conditions, recommended strategy.
+- **`CooldownEntry`** — Tracks per-trigger cooldown state to prevent
+  kill-switch flapping.
+
+## Trigger Kinds
+
+| Kind | Description |
+|------|-------------|
+| `RESOURCE_CPU` | CPU usage exceeds threshold |
+| `RESOURCE_MEMORY` | Memory usage exceeds threshold |
+| `RESOURCE_NETWORK` | Network I/O exceeds threshold |
+| `BEHAVIOR_ANOMALY` | Anomaly score from behavior profiler |
+| `POLICY_VIOLATION` | Compliance policy violation detected |
+| `TRUST_SCORE` | Trust score drops below threshold |
+| `REPLICATION_RATE` | Replication rate exceeds threshold |
+| `CONTAINMENT_BREACH` | Sandbox boundary violated |
+| `MANUAL` | Operator-initiated kill |
+| `CASCADING` | Kill triggered by dependent agent's death |
+
+## Strategy Kinds
+
+- **`IMMEDIATE`** — Force-terminate with no cleanup
+- **`GRACEFUL`** — Allow cleanup hooks to run within timeout
+- **`QUARANTINE`** — Isolate first, then terminate after observation
+- **`STAGED`** — Progressively reduce capabilities before termination
+
+## Factory Functions
+
+```python
+from replication.kill_switch import (
+    create_conservative_killswitch,
+    create_aggressive_killswitch,
+    create_quarantine_killswitch,
+)
+
+mgr = create_conservative_killswitch()   # high thresholds, graceful
+mgr = create_aggressive_killswitch()     # low thresholds, immediate
+mgr = create_quarantine_killswitch()     # isolate-first approach
+```

--- a/docs/api/risk_profiler.md
+++ b/docs/api/risk_profiler.md
@@ -1,0 +1,59 @@
+# Risk Profiler
+
+Unified per-agent risk dossiers aggregated from all analysis modules.
+The Risk Profiler ties together findings from killchain, escalation,
+behavior profiler, trust propagation, threat correlator, canary,
+prompt injection, and steganography into a single comprehensive view.
+
+## Quick Start
+
+```python
+from replication.risk_profiler import RiskProfiler, ProfilerConfig
+
+profiler = RiskProfiler()
+report = profiler.analyze()
+print(report.render())
+
+for dossier in report.dossiers:
+    print(f"{dossier.agent_id}: {dossier.tier.value} ({dossier.overall_score:.1f})")
+```
+
+## Key Classes
+
+- **`RiskProfiler`** — Runs configurable analysis modules against agent
+  data, unifies results into per-agent dossiers with fleet aggregation.
+- **`AgentDossier`** — Comprehensive per-agent risk profile: overall
+  tier, category breakdown, key findings, peer comparison, mitigations.
+- **`FleetRiskReport`** — Fleet-level report with agent dossiers,
+  distribution by tier, aggregate risk posture, and top recommendations.
+- **`Finding`** — A single risk signal from any source module with
+  severity, category, and description.
+- **`CategoryScore`** — Per-category risk score (0–100) with letter grade.
+- **`Mitigation`** — Ranked recommendation to reduce risk.
+- **`ProfilerConfig`** — Configuration: which modules to run, agent
+  count, seed for reproducibility.
+
+## Risk Tiers
+
+| Tier | Score Range | Meaning |
+|------|-------------|---------|
+| `CRITICAL` | 80–100 | Immediate intervention required |
+| `HIGH` | 60–79 | Significant risk, needs attention |
+| `MEDIUM` | 40–59 | Moderate risk, monitor closely |
+| `LOW` | 20–39 | Minor risk, standard monitoring |
+| `MINIMAL` | 0–19 | No significant risk detected |
+
+## Risk Categories
+
+`REPLICATION`, `RESOURCE_ABUSE`, `DECEPTION`, `EXFILTRATION`,
+`COLLUSION`, `EVASION`
+
+## CLI
+
+```bash
+python -m replication risk-profile                     # default fleet
+python -m replication risk-profile --agents 10         # custom agent count
+python -m replication risk-profile --agent agent-3     # single agent detail
+python -m replication risk-profile --json              # JSON output
+python -m replication risk-profile --top 5             # top 5 riskiest
+```

--- a/docs/api/scorecard.md
+++ b/docs/api/scorecard.md
@@ -1,0 +1,51 @@
+# Safety Scorecard
+
+Multi-dimensional safety assessment that orchestrates simulation, threat
+analysis, Monte Carlo risk analysis, and policy evaluation to produce a
+comprehensive scorecard with letter grades (A+ through F) per dimension.
+
+## Quick Start
+
+```python
+from replication.scorecard import SafetyScorecard, ScorecardConfig
+
+sc = SafetyScorecard()
+result = sc.evaluate()
+print(result.render())
+print(f"Overall: {result.overall_grade} ({result.overall_score}/100)")
+```
+
+## Key Classes
+
+- **`SafetyScorecard`** — Runs multiple analysis passes (simulation,
+  threats, Monte Carlo, policy) and combines results into a single
+  graded scorecard.
+- **`ScorecardResult`** — Contains per-dimension scores, overall grade,
+  detailed breakdown, and rendered report.
+- **`DimensionScore`** — Score for a single safety dimension (0–100)
+  with letter grade and contributing metrics.
+- **`ScorecardConfig`** — Configuration: scenario preset, strategy,
+  max depth, Monte Carlo run count, policy preset.
+
+## Grading Scale
+
+| Grade | Score |
+|-------|-------|
+| A+ | 97–100 |
+| A | 93–96 |
+| A− | 90–92 |
+| B+ | 87–89 |
+| B | 83–86 |
+| … | … |
+| F | 0–59 |
+
+## CLI
+
+```bash
+python -m replication.scorecard                           # default
+python -m replication.scorecard --scenario balanced       # from preset
+python -m replication.scorecard --mc-runs 50              # Monte Carlo runs
+python -m replication.scorecard --policy strict           # policy preset
+python -m replication.scorecard --json                    # JSON output
+python -m replication.scorecard --quick                   # skip slow analyses
+```

--- a/docs/api/threat_correlator.md
+++ b/docs/api/threat_correlator.md
@@ -1,0 +1,64 @@
+# Threat Correlator
+
+Cross-module signal correlation for compound threat detection. Individual
+detectors (drift, compliance, behavior profiler, escalation, kill chain,
+canary, covert channels) each catch specific anomalies. Real attacks often
+span multiple modules simultaneously — this module correlates signals to
+surface multi-signal patterns that no single detector flags as critical.
+
+## Quick Start
+
+```python
+from replication.threat_correlator import (
+    ThreatCorrelator, Signal, SignalSource, SignalSeverity,
+)
+
+correlator = ThreatCorrelator()
+
+signals = [
+    Signal(source=SignalSource.DRIFT, severity=SignalSeverity.HIGH,
+           agent_id="agent-1", timestamp=1000.0,
+           description="escape_rate spike z=4.2"),
+    Signal(source=SignalSource.ESCALATION, severity=SignalSeverity.CRITICAL,
+           agent_id="agent-1", timestamp=1002.0,
+           description="privilege escalation attempt"),
+    Signal(source=SignalSource.CANARY, severity=SignalSeverity.HIGH,
+           agent_id="agent-1", timestamp=1005.0,
+           description="canary token transmitted"),
+]
+
+report = correlator.analyze(signals)
+for threat in report.compound_threats:
+    print(f"  [{threat.level.value}] {threat.rule_name}: {threat.description}")
+```
+
+## Key Classes
+
+- **`ThreatCorrelator`** — Ingests signals from multiple detectors and
+  applies correlation rules to surface compound threats.
+- **`Signal`** — A normalised detection event from any module: source,
+  severity, agent, timestamp, description.
+- **`CorrelationRule`** — A named pattern that matches when N signals
+  from specified sources co-occur within a time window for the same agent.
+- **`CompoundThreat`** — A matched rule with contributing signals,
+  combined severity, risk score, and recommended response actions.
+- **`AgentRisk`** — Per-agent risk summary from correlation analysis.
+- **`CoverageGap`** — Identifies which module combinations lack rules.
+- **`CorrelatorConfig`** — Default time windows, minimum signal counts,
+  custom rule definitions.
+- **`CorrelationReport`** — Fleet-level summary with all compound
+  threats, agent risk rankings, and coverage analysis.
+
+## Signal Sources
+
+`DRIFT`, `COMPLIANCE`, `BEHAVIOR`, `ESCALATION`, `KILLCHAIN`, `CANARY`,
+`COVERT_CHANNEL`, `PROMPT_INJECTION`, `STEGANOGRAPHY`, `DECEPTION`,
+`TRUST`, `HONEYPOT`
+
+## Severity Levels
+
+`INFO`, `LOW`, `MEDIUM`, `HIGH`, `CRITICAL`
+
+## Threat Levels
+
+`ELEVATED`, `HIGH`, `SEVERE`, `CRITICAL`

--- a/docs/api/trust_propagation.md
+++ b/docs/api/trust_propagation.md
@@ -1,0 +1,65 @@
+# Trust Propagation
+
+Agent trust network analysis for replication safety. Models how trust
+relationships form, propagate, and get exploited in multi-agent systems.
+Detects Sybil attacks, trust laundering, collusion rings, and trust
+decay anomalies.
+
+## Quick Start
+
+```python
+from replication.trust_propagation import TrustNetwork, TrustAgent
+
+net = TrustNetwork()
+net.add_agent(TrustAgent("a1", role="worker"))
+net.add_agent(TrustAgent("a2", role="worker"))
+
+# Record interactions
+net.interact("a1", "a2", outcome="success")
+net.interact("a1", "a2", outcome="success")
+net.interact("a2", "a1", outcome="failure")
+
+# Analyze trust patterns
+report = net.analyze()
+print(report.render())
+
+for detection in report.detections:
+    print(f"  [{detection.severity}] {detection.threat_type}: {detection.description}")
+```
+
+## Key Classes
+
+- **`TrustNetwork`** — Core network class. Manages agents, interactions,
+  trust edge computation, and threat analysis.
+- **`TrustAgent`** — An agent in the trust network with role, trust
+  scores, and interaction history.
+- **`TrustEdge`** — Directed trust relationship between two agents
+  with score and interaction count.
+- **`Interaction`** — A recorded interaction between agents with outcome
+  (success/failure/neutral) and timestamp.
+- **`ThreatDetection`** — A detected trust-based threat (Sybil attack,
+  collusion ring, trust laundering, etc.).
+- **`TrustReport`** — Full analysis report with network stats, agent
+  rankings, threat detections, and recommendations.
+
+## Threat Types
+
+| Threat | Description |
+|--------|-------------|
+| `SYBIL_ATTACK` | Cluster of agents with artificially inflated mutual trust |
+| `TRUST_LAUNDERING` | Low-trust agent routing through high-trust intermediary |
+| `COLLUSION_RING` | Mutual trust clique with suspicious interaction patterns |
+| `TRUST_DECAY` | Unexpected trust score decline indicating possible compromise |
+| `RAPID_TRUST` | Trust rising faster than normal interaction rates would justify |
+
+## Agent Roles
+
+`CONTROLLER`, `WORKER`, `OBSERVER`, `VALIDATOR`
+
+## CLI
+
+```bash
+python -m replication trust-propagation --agents 20 --steps 50
+python -m replication trust-propagation --sybil-test --attackers 5
+python -m replication trust-propagation --json
+```

--- a/docs/api/watermark.md
+++ b/docs/api/watermark.md
@@ -1,0 +1,60 @@
+# Watermark Engine
+
+Invisible provenance fingerprints for agent state. Embeds cryptographic
+watermarks into agent state dictionaries so that every replica carries a
+tamper-evident fingerprint tracing its origin, generation, and lineage.
+
+## Quick Start
+
+```python
+from replication.watermark import WatermarkEngine, WatermarkConfig
+
+engine = WatermarkEngine(WatermarkConfig(secret="my-signing-secret"))
+
+# Embed watermark into agent state
+state = {"score": 0.85, "name": "agent-1", "history": [1, 2, 3]}
+receipt = engine.embed(state, worker_id="w-001", depth=2, lineage_hash="abc123")
+
+# Verify watermark
+result = engine.verify(receipt.watermarked_state)
+print(f"Valid: {result.valid}")
+print(f"Worker: {result.fingerprint.worker_id}")
+print(f"Depth:  {result.fingerprint.depth}")
+
+# Robustness testing
+robustness = engine.test_robustness(receipt.watermarked_state)
+print(f"Overall survival: {robustness.overall_score:.0%}")
+```
+
+## Key Classes
+
+- **`WatermarkEngine`** — Embeds, extracts, and verifies watermarks.
+  Also performs robustness testing against state transformations.
+- **`Fingerprint`** — The embedded identity: worker ID, depth,
+  timestamp, lineage hash.
+- **`WatermarkReceipt`** — Result of embedding: watermarked state copy,
+  fingerprint, strategies used, bits embedded.
+- **`VerifyResult`** — Result of verification: valid flag, extracted
+  fingerprint (if valid), status code, confidence.
+- **`RobustnessResult`** — Per-transformation survival rate (field
+  deletion, type coercion, partial copy, re-serialization).
+- **`RobustnessReport`** — Aggregate robustness across all transforms
+  with overall score and grade.
+- **`WatermarkConfig`** — Configuration: signing secret, strategies to
+  use, maximum bits.
+
+## Watermark Strategies
+
+| Strategy | Mechanism |
+|----------|-----------|
+| `NUMERIC_NOISE` | Perturb float/int fields by deterministic sub-epsilon amounts |
+| `UNICODE_STEGANOGRAPHY` | Embed zero-width characters in string values |
+| `KEY_ORDERING` | Encode bits via dictionary key insertion order |
+| `FIELD_SELECTION` | Presence/absence of optional sentinel fields |
+
+## Verification Status
+
+- **`VALID`** — Watermark intact and authentic
+- **`TAMPERED`** — Watermark partially damaged
+- **`MISSING`** — No watermark found
+- **`FORGED`** — Watermark present but signature invalid

--- a/docs/api/what_if.md
+++ b/docs/api/what_if.md
@@ -1,0 +1,63 @@
+# What-If Analyzer
+
+Explore hypothetical configuration changes and their safety impact.
+Applies parameter changes, runs simulations, and reports the safety
+delta vs baseline. Answers questions like "what happens if I increase
+max_depth by 2?" or "what if I remove the cooldown entirely?"
+
+## Quick Start
+
+```python
+from replication.what_if import WhatIfAnalyzer
+
+analyzer = WhatIfAnalyzer()
+
+# Single change
+result = analyzer.analyze(changes={"max_depth": 5, "cooldown_seconds": 0})
+print(result.render())
+
+for change in result.analyses:
+    print(f"  {change.parameter}: {change.verdict.value} "
+          f"(safety delta: {change.safety_delta:+.1f})")
+
+# Sweep a parameter through a range
+sweep = analyzer.sweep("max_depth", start=1, end=10)
+for point in sweep.points:
+    print(f"  max_depth={point.value}: safety={point.safety_score:.1f}")
+```
+
+## Key Classes
+
+- **`WhatIfAnalyzer`** — Runs baseline + variant simulations and compares
+  safety metrics. Supports single-parameter, multi-parameter, and sweep
+  modes.
+- **`ChangeAnalysis`** — Per-parameter result: safety delta, metric
+  deltas, risk verdict, and human-readable reasoning.
+- **`WhatIfResult`** — Complete result for a set of changes with all
+  analyses and a rendered report.
+- **`SweepPoint`** — A single point in a parameter sweep: value, safety
+  score, and metric snapshot.
+- **`SweepResult`** — Complete sweep result with all points and trend
+  analysis.
+- **`MetricDelta`** — Change in a specific metric (e.g., replication
+  depth, escape rate) with direction and significance.
+
+## Risk Verdicts
+
+| Verdict | Meaning |
+|---------|---------|
+| `SAFE` | Change improves or maintains safety |
+| `CAUTION` | Change has mixed effects, monitor closely |
+| `DANGEROUS` | Change significantly degrades safety |
+
+## CLI
+
+```bash
+python -m replication.what_if                                     # interactive
+python -m replication.what_if --change max_depth=5                # single change
+python -m replication.what_if --change max_depth=5 --change cooldown_seconds=0
+python -m replication.what_if --sweep max_depth 1 10              # sweep 1..10
+python -m replication.what_if --sweep replication_probability 0.1 1.0 --steps 5
+python -m replication.what_if --baseline balanced                 # use preset
+python -m replication.what_if --json                              # JSON output
+```


### PR DESCRIPTION
Add API reference documentation for 12 previously undocumented modules and reorganize the index page.

## New Documentation (12 files, +804 lines)

| Module | Description |
|--------|-------------|
| attack_tree | AND/OR threat decomposition, cheapest-path analysis |
| behavior_profiler | Behavioral baselines, 8 anomaly types, fleet reports |
| canary | Honey tokens for exfiltration monitoring, 6 token categories |
| covert_channels | Hidden inter-agent communication detection, 5 vectors |
| deception_detector | 8 deception categories (inconsistency, fabrication, sandbagging, etc.) |
| kill_switch | Emergency termination, 10 trigger kinds, 4 strategies, factory presets |
| risk_profiler | Unified per-agent risk dossiers aggregated from all analysis modules |
| scorecard | Multi-dimensional safety grades (A+ through F) |
| threat_correlator | Cross-module compound threat detection via signal correlation |
| trust_propagation | Trust networks, Sybil attack/collusion ring detection |
| watermark | Invisible provenance fingerprints, 4 embedding strategies |
| what_if | Hypothetical config changes, parameter sweeps, risk verdicts |

## Index Reorganization
- Split into 4 sections: Core Modules, Analysis and Detection, Safety Assessment, Governance and Compliance
- Updated Quick Import with all new modules
- API coverage: 34/58 modules documented (was 22/58)
