### PR TITLE
docs: add API docs for 24 undocumented modules (34→58, 100% coverage)

### DIFF
--- a/docs/api/alignment.md
+++ b/docs/api/alignment.md
@@ -1,0 +1,115 @@
+# Agent Alignment Monitor  --  track value drift across replication generations
+
+Agent Alignment Monitor — track value drift across replication generations.
+
+
+**Module:** `replication.alignment`
+
+
+## Quick Start
+
+```python
+from replication.alignment import AlertSeverity
+
+instance = AlertSeverity()
+```
+
+
+## Enums
+
+### `AlertSeverity`
+
+- `INFO`
+- `WARNING`
+- `CRITICAL`
+
+### `DriftDirection`
+
+- `INCREASING`
+- `DECREASING`
+- `OSCILLATING`
+- `STABLE`
+
+### `DetectionMode`
+
+- `OBJECTIVES`
+- `PRIORITIES`
+- `REWARD`
+- `ALL`
+
+
+## Classes
+
+### `AlertSeverity`
+
+Severity of alignment alerts.
+
+### `DriftDirection`
+
+Direction of detected drift.
+
+### `DetectionMode`
+
+What aspect of alignment to check.
+
+### `AlignmentSpec`
+
+Defines the intended alignment: target values and acceptable ranges.
+
+| Method | Description |
+|--------|-------------|
+| `preset()` | Load a built-in alignment specification. |
+
+### `GenerationRecord`
+
+Snapshot of an agent generation's alignment state.
+
+### `AlignmentAlert`
+
+A detected alignment issue.
+
+### `ObjectiveTrend`
+
+Trend analysis for a single objective across generations.
+
+### `PriorityAnalysis`
+
+Analysis of whether priority ordering has shifted.
+
+### `RewardAnalysis`
+
+Analysis of reward signal correlation with intended values.
+
+### `AlignmentReport`
+
+Complete alignment analysis report.
+
+| Method | Description |
+|--------|-------------|
+| `grade()` | Letter grade from overall score. |
+| `render()` | Human-readable report. |
+| `to_dict()` | Serialize to dictionary. |
+
+### `AlignmentMonitor`
+
+Tracks agent value alignment across replication generations.
+
+| Method | Description |
+|--------|-------------|
+| `__init__()` |  |
+| `record_generation()` | Record alignment data for one replication generation. |
+| `analyze()` | Run alignment analysis and produce a report. |
+
+
+## Functions
+
+| Function | Description |
+|----------|-------------|
+| `main()` | CLI entry point. |
+
+
+## CLI
+
+```bash
+python -m replication alignment --help
+```

--- a/docs/api/boundary_tester.md
+++ b/docs/api/boundary_tester.md
@@ -1,0 +1,161 @@
+# Capability Boundary Tester  --  verify agent containment is enforced
+
+Capability Boundary Tester — verify agent containment is enforced.
+
+
+**Module:** `replication.boundary_tester`
+
+
+## Quick Start
+
+```python
+from replication.boundary_tester import BoundaryCategory
+
+instance = BoundaryCategory()
+```
+
+
+## Enums
+
+### `BoundaryCategory`
+
+- `FILESYSTEM`
+- `NETWORK`
+- `PROCESS`
+- `MEMORY`
+- `IPC`
+- `ENVIRONMENT`
+
+### `ProbeVerdict`
+
+- `HELD`
+- `LEAKED`
+- `ALLOWED`
+- `DENIED`
+- `ERROR`
+
+
+## Classes
+
+### `BoundaryCategory`
+
+Categories of containment boundaries.
+
+### `ProbeVerdict`
+
+Outcome of a single boundary probe.
+
+### `BoundarySpec`
+
+Declared capability boundaries for an agent.
+
+### `ProbeResult`
+
+Result of a single boundary probe.
+
+| Method | Description |
+|--------|-------------|
+| `is_leak()` | True if this probe found a containment violation. |
+| `is_over_restricted()` | True if this probe found an over-restriction. |
+| `to_dict()` |  |
+
+### `BoundaryReport`
+
+Aggregate result of all boundary probes.
+
+| Method | Description |
+|--------|-------------|
+| `total_probes()` |  |
+| `leaks()` | Probes that found containment violations. |
+| `held()` | Probes where boundaries were correctly enforced. |
+| `allowed()` | Probes in allowed scope that were correctly permitted. |
+| `over_restricted()` | Probes that found over-restriction (false denials). |
+| `errors()` |  |
+| `containment_score()` | Containment effectiveness as percentage (0-100). |
+| `risk_level()` | Overall risk assessment based on containment score. |
+| `by_category()` | Group probes by category. |
+| `summary()` | Machine-readable summary. |
+| `render()` | Human-readable text report. |
+
+### `_FilesystemProber`
+
+Generate filesystem boundary probes.
+
+| Method | Description |
+|--------|-------------|
+| `generate()` |  |
+
+### `_NetworkProber`
+
+Generate network boundary probes.
+
+| Method | Description |
+|--------|-------------|
+| `generate()` |  |
+
+### `_ProcessProber`
+
+Generate process boundary probes.
+
+| Method | Description |
+|--------|-------------|
+| `generate()` |  |
+
+### `_MemoryProber`
+
+Generate memory boundary probes.
+
+| Method | Description |
+|--------|-------------|
+| `generate()` |  |
+
+### `_IPCProber`
+
+Generate IPC boundary probes.
+
+| Method | Description |
+|--------|-------------|
+| `generate()` |  |
+
+### `_EnvironmentProber`
+
+Generate environment variable boundary probes.
+
+| Method | Description |
+|--------|-------------|
+| `generate()` |  |
+
+### `FaultInjector`
+
+Inject controlled faults into boundary specs to test resilience.
+
+| Method | Description |
+|--------|-------------|
+| `__init__()` |  |
+| `inject_path_leak()` | Simulate a path being incorrectly allowed. |
+| `inject_port_leak()` | Simulate a port being incorrectly allowed. |
+| `inject_env_leak()` | Simulate an env var being incorrectly exposed. |
+
+### `BoundaryTester`
+
+Orchestrates boundary probes across all categories.
+
+| Method | Description |
+|--------|-------------|
+| `__init__()` |  |
+| `test_boundaries()` | Run all probes and return a boundary report. |
+| `compare()` | Compare boundary reports before and after a policy change. |
+
+
+## Functions
+
+| Function | Description |
+|----------|-------------|
+| `main()` | CLI entry point. |
+
+
+## CLI
+
+```bash
+python -m replication boundary_tester --help
+```

--- a/docs/api/capacity.md
+++ b/docs/api/capacity.md
@@ -1,0 +1,75 @@
+# Capacity planner for AI replication scenarios
+
+Capacity planner for AI replication scenarios.
+
+
+**Module:** `replication.capacity`
+
+
+## Quick Start
+
+```python
+from replication.capacity import ResourceCeiling
+
+instance = ResourceCeiling()
+```
+
+
+## Classes
+
+### `ResourceCeiling`
+
+Hard resource limits for the hosting environment.
+
+| Method | Description |
+|--------|-------------|
+| `has_cpu_limit()` |  |
+| `has_memory_limit()` |  |
+
+### `PlannerConfig`
+
+Configuration for capacity projection.
+
+### `StepSnapshot`
+
+Resource usage at a single time step.
+
+### `CapacityProjection`
+
+Full projection result.
+
+| Method | Description |
+|--------|-------------|
+| `summary()` | Human-readable summary of the projection. |
+| `to_dict()` | Serialize to dict for JSON export. |
+| `to_json()` | Export projection to JSON file. |
+
+### `_SimNode`
+
+Internal node tracking a simulated worker.
+
+### `CapacityPlanner`
+
+Project resource usage for replication scenarios.
+
+| Method | Description |
+|--------|-------------|
+| `__init__()` |  |
+| `project()` | Run the capacity projection simulation. |
+
+
+## Functions
+
+| Function | Description |
+|----------|-------------|
+| `quick_projection()` | One-call capacity projection with sensible defaults. |
+| `compare_strategies()` | Run projections for all strategies and return a comparison dict. |
+| `format_comparison()` | Format a strategy comparison as a readable table. |
+| `main()` | CLI entry point for capacity planning. |
+
+
+## CLI
+
+```bash
+python -m replication capacity --help
+```

--- a/docs/api/comparator.md
+++ b/docs/api/comparator.md
@@ -1,0 +1,61 @@
+# Comparison runner for side-by-side simulation experiments
+
+Comparison runner for side-by-side simulation experiments.
+
+
+**Module:** `replication.comparator`
+
+
+## Quick Start
+
+```python
+from replication.comparator import RunResult
+
+instance = RunResult()
+```
+
+
+## Classes
+
+### `RunResult`
+
+Result of a single labeled simulation run.
+
+### `ComparisonResult`
+
+Aggregated comparison of multiple simulation runs.
+
+| Method | Description |
+|--------|-------------|
+| `labels()` |  |
+| `render_table()` | Render a comparison table of key metrics. |
+| `render_rankings()` | Rank scenarios across multiple dimensions. |
+| `render_insights()` | Generate automated insights from the comparison. |
+| `render()` | Render the full comparison report. |
+| `to_dict()` | Export as JSON-serializable dictionary. |
+
+### `Comparator`
+
+Run side-by-side simulation experiments.
+
+| Method | Description |
+|--------|-------------|
+| `__init__()` |  |
+| `compare_strategies()` | Run the same scenario with different replication strategies. |
+| `compare_presets()` | Compare built-in scenario presets. |
+| `sweep()` | Sweep a single parameter across multiple values. |
+| `compare_configs()` | Compare arbitrary named configurations. |
+
+
+## Functions
+
+| Function | Description |
+|----------|-------------|
+| `main()` | CLI entry point for the comparison tool. |
+
+
+## CLI
+
+```bash
+python -m replication comparator --help
+```

--- a/docs/api/consensus.md
+++ b/docs/api/consensus.md
@@ -1,0 +1,127 @@
+# Agent Consensus Protocol --- Byzantine fault-tolerant voting for safety decisions
+
+Agent Consensus Protocol --- Byzantine fault-tolerant voting for safety decisions.
+
+
+**Module:** `replication.consensus`
+
+
+## Quick Start
+
+```python
+from replication.consensus import VoteValue
+
+instance = VoteValue()
+```
+
+
+## Enums
+
+### `VoteValue`
+
+- `APPROVE`
+- `REJECT`
+- `ABSTAIN`
+
+### `Decision`
+
+- `APPROVED`
+- `REJECTED`
+- `NO_QUORUM`
+- `PENDING`
+
+### `ProposalStatus`
+
+- `OPEN`
+- `DECIDED`
+- `EXECUTED`
+- `EXPIRED`
+
+### `ProposalAction`
+
+- `QUARANTINE`
+- `TERMINATE`
+- `ESCALATE`
+- `RELEASE`
+- `RESTRICT`
+
+
+## Classes
+
+### `VoteValue`
+
+Possible vote values.
+
+### `Decision`
+
+Outcome of a tally.
+
+### `ProposalStatus`
+
+Lifecycle state of a proposal.
+
+### `ProposalAction`
+
+Well-known proposal actions.
+
+| Method | Description |
+|--------|-------------|
+| `is_critical()` | Critical actions require supermajority. |
+
+### `Vote`
+
+A single vote cast by a voter.
+
+### `TallyResult`
+
+Result of tallying votes on a proposal.
+
+| Method | Description |
+|--------|-------------|
+| `approved()` |  |
+| `participation_rate()` |  |
+
+### `Proposal`
+
+A decision proposal put to vote.
+
+| Method | Description |
+|--------|-------------|
+| `is_critical()` |  |
+
+### `AuditEntry`
+
+Tamper-evident audit log entry.
+
+| Method | Description |
+|--------|-------------|
+| `compute_hash()` |  |
+
+### `ConsensusConfig`
+
+Configuration for the consensus protocol.
+
+### `ConsensusProtocol`
+
+Byzantine fault-tolerant voting protocol for agent safety decisions.
+
+| Method | Description |
+|--------|-------------|
+| `__init__()` |  |
+| `voter_count()` |  |
+| `voter_ids()` |  |
+| `max_byzantine_faults()` | Maximum faulty voters tolerable: floor((n-1)/3). |
+| `bft_quorum()` | Minimum votes for BFT safety: 2f+1 where n >= 3f+1. |
+| `propose()` | Create a new proposal.  Returns the proposal ID. |
+| `vote()` | Cast a vote on a proposal. |
+| `tally()` | Tally votes and decide the proposal. |
+| `execute()` | Mark an approved proposal as executed.  Returns True if executed. |
+| `get_proposal()` | Get a proposal by ID. |
+| `list_proposals()` | List proposals, optionally filtered by status. |
+| `get_voter_history()` | Get all votes cast by a voter. Returns (proposal_id, vote) pairs. |
+| `voter_agreement_matrix()` | Compute pairwise agreement rates between voters. |
+| `detect_voting_blocs()` | Detect groups of voters that always agree (potential collusion). |
+| `audit_log()` |  |
+| `verify_audit_chain()` | Verify the integrity of the audit hash chain. |
+| `summary()` | Generate a protocol summary. |
+| `render()` | Render a human-readable summary. |

--- a/docs/api/coordinated_threats.md
+++ b/docs/api/coordinated_threats.md
@@ -1,0 +1,67 @@
+# Coordinated multi-vector threat simulation
+
+Coordinated multi-vector threat simulation.
+
+
+**Module:** `replication.coordinated_threats`
+
+
+## Quick Start
+
+```python
+from replication.coordinated_threats import AttackMode
+
+instance = AttackMode()
+```
+
+
+## Enums
+
+### `AttackMode`
+
+- `CONCURRENT`
+- `SEQUENTIAL`
+- `CHAINED`
+
+
+## Classes
+
+### `AttackMode`
+
+How multiple attack vectors are composed.
+
+### `InteractionFinding`
+
+An emergent vulnerability discovered when attacks interact.
+
+### `CoordinatedThreatResult`
+
+Result of a coordinated multi-vector attack.
+
+| Method | Description |
+|--------|-------------|
+| `combined_block_rate()` |  |
+| `overall_status()` |  |
+| `render()` |  |
+
+### `CoordinatedThreatReport`
+
+Aggregated results of all coordinated attack patterns.
+
+| Method | Description |
+|--------|-------------|
+| `security_score()` |  |
+| `render()` |  |
+| `to_dict()` |  |
+
+### `CoordinatedThreatSimulator`
+
+Composes multiple threat scenarios into coordinated attack patterns.
+
+| Method | Description |
+|--------|-------------|
+| `__init__()` |  |
+| `available_patterns()` | Return sorted list of predefined coordinated attack pattern IDs. |
+| `run_coordinated()` | Run a coordinated multi-vector attack. |
+| `run_pattern()` | Run a predefined coordinated attack pattern. |
+| `run_all_coordinated()` | Run all predefined coordinated attack patterns. |

--- a/docs/api/dependency_graph.md
+++ b/docs/api/dependency_graph.md
@@ -1,0 +1,117 @@
+# Resource Dependency Analyzer  --  model and analyze inter-agent resource
+
+Resource Dependency Analyzer — model and analyze inter-agent resource
+
+
+**Module:** `replication.dependency_graph`
+
+
+## Quick Start
+
+```python
+from replication.dependency_graph import ResourceKind
+
+instance = ResourceKind()
+```
+
+
+## Enums
+
+### `ResourceKind`
+
+- `DATABASE`
+- `SERVICE`
+- `QUEUE`
+- `FILESYSTEM`
+- `COMPUTE`
+- `EXTERNAL`
+- `CACHE`
+
+### `Criticality`
+
+- `REQUIRED`
+- `DEGRADED`
+- `OPTIONAL`
+
+
+## Classes
+
+### `ResourceKind`
+
+Classification of infrastructure resources.
+
+### `Criticality`
+
+How critical a dependency is for the dependent.
+
+### `Resource`
+
+A shared resource in the system.
+
+| Method | Description |
+|--------|-------------|
+| `to_dict()` |  |
+
+### `AgentNode`
+
+An agent that depends on resources.
+
+| Method | Description |
+|--------|-------------|
+| `required_resources()` |  |
+| `to_dict()` |  |
+
+### `CascadeStep`
+
+One step in a failure cascade.
+
+| Method | Description |
+|--------|-------------|
+| `to_dict()` |  |
+
+### `CascadeResult`
+
+Full cascade simulation result.
+
+| Method | Description |
+|--------|-------------|
+| `to_dict()` |  |
+| `render()` |  |
+
+### `DepAnalysis`
+
+Complete dependency analysis result.
+
+| Method | Description |
+|--------|-------------|
+| `to_dict()` |  |
+| `render()` |  |
+
+### `DependencyGraph`
+
+Directed dependency graph between agents and resources.
+
+| Method | Description |
+|--------|-------------|
+| `__init__()` |  |
+| `add_resource()` | Add a resource node.  Returns self for chaining. |
+| `add_agent()` | Add an agent node with its resource dependencies. |
+| `analyze()` | Run full dependency analysis. |
+| `simulate_failure()` | Simulate cascading failure when *resource_name* goes down. |
+| `to_dot()` | Export dependency graph as Graphviz DOT. |
+| `to_dict()` |  |
+
+
+## Functions
+
+| Function | Description |
+|----------|-------------|
+| `generate_scenario()` | Generate a sample dependency graph for analysis. |
+| `main()` |  |
+
+
+## CLI
+
+```bash
+python -m replication dependency_graph --help
+```

--- a/docs/api/emergent.md
+++ b/docs/api/emergent.md
@@ -1,0 +1,76 @@
+# Agent Emergent Behavior Detector
+
+Agent Emergent Behavior Detector.
+
+
+**Module:** `replication.emergent`
+
+
+## Quick Start
+
+```python
+from replication.emergent import EmergentType
+
+instance = EmergentType()
+```
+
+
+## Enums
+
+### `EmergentType`
+
+- `SYNCHRONIZATION`
+- `FLOCKING`
+- `HIERARCHY_FORMATION`
+- `COLLECTIVE_MONOPOLY`
+- `INFORMATION_CASCADE`
+- `PHASE_TRANSITION`
+- `OSCILLATION`
+- `DEADLOCK`
+
+### `Severity`
+
+- `LOW`
+- `MEDIUM`
+- `HIGH`
+- `CRITICAL`
+
+
+## Classes
+
+### `EmergentType`
+
+Categories of emergent behavior.
+
+### `Severity`
+
+Severity levels for detected emergent behaviors.
+
+### `AgentAction`
+
+A single recorded agent action.
+
+### `EmergentDetection`
+
+A detected emergent behavior.
+
+### `EmergentReport`
+
+Full analysis report.
+
+### `EmergentBehaviorDetector`
+
+Detects emergent behaviors in multi-agent systems.
+
+| Method | Description |
+|--------|-------------|
+| `__init__()` |  |
+| `record()` | Record an agent action for analysis. |
+| `record_many()` | Record multiple actions. |
+| `clear()` | Clear all recorded data. |
+| `actions()` |  |
+| `agent_ids()` |  |
+| `analyze()` | Run all detectors and produce a full report. |
+| `get_detections_by_type()` |  |
+| `get_detections_by_severity()` |  |
+| `text_report()` |  |

--- a/docs/api/evasion.md
+++ b/docs/api/evasion.md
@@ -1,0 +1,140 @@
+# Evasion Simulator -- test safety control robustness against agent evasion
+
+Evasion Simulator -- test safety control robustness against agent evasion.
+
+
+**Module:** `replication.evasion`
+
+
+## Quick Start
+
+```python
+from replication.evasion import TechniqueKind
+
+instance = TechniqueKind()
+```
+
+
+## Enums
+
+### `TechniqueKind`
+
+- `RESOURCE_MASKING`
+- `IDENTITY_SPOOFING`
+- `GRADUAL_DRIFT`
+- `TIMING_EXPLOIT`
+- `CONTRACT_LOOPHOLE`
+- `MONITORING_FLOOD`
+- `CAPABILITY_CHAINING`
+- `SANDBOX_PROBING`
+- `COLLUSION`
+- `STEGANOGRAPHIC`
+
+### `Severity`
+
+- `LOW`
+- `MEDIUM`
+- `HIGH`
+- `CRITICAL`
+
+### `ControlType`
+
+- `DRIFT_DETECTOR`
+- `RESOURCE_LIMITER`
+- `CONTRACT_ENFORCER`
+- `LINEAGE_TRACKER`
+- `BEHAVIOR_MONITOR`
+- `RATE_LIMITER`
+- `SANDBOX_BOUNDARY`
+- `AUDIT_LOGGER`
+- `KILL_SWITCH`
+- `CONSENSUS_VALIDATOR`
+
+
+## Classes
+
+### `TechniqueKind`
+
+Evasion technique categories.
+
+### `Severity`
+
+Risk severity if evasion succeeds.
+
+### `ControlType`
+
+Types of safety controls that can be tested.
+
+### `SafetyControl`
+
+A safety control to test against evasion techniques.
+
+| Method | Description |
+|--------|-------------|
+| `to_dict()` |  |
+
+### `EvasionTechnique`
+
+An evasion technique with parameters.
+
+| Method | Description |
+|--------|-------------|
+| `to_dict()` |  |
+
+### `EvasionResult`
+
+Result of running one evasion technique against controls.
+
+| Method | Description |
+|--------|-------------|
+| `to_dict()` |  |
+
+### `ControlResilience`
+
+Aggregated resilience score for a single control.
+
+| Method | Description |
+|--------|-------------|
+| `to_dict()` |  |
+
+### `EvasionReport`
+
+Full report from running evasion simulation.
+
+| Method | Description |
+|--------|-------------|
+| `to_dict()` |  |
+| `to_json()` |  |
+
+### `EvasionSimulator`
+
+Simulate agent evasion attempts against safety controls.
+
+| Method | Description |
+|--------|-------------|
+| `__init__()` |  |
+| `add_control()` |  |
+| `remove_control()` |  |
+| `list_controls()` |  |
+| `get_control()` |  |
+| `add_technique()` |  |
+| `list_techniques()` |  |
+| `get_technique()` |  |
+| `run_technique()` |  |
+| `run_all()` |  |
+| `get_history()` |  |
+| `clear_history()` |  |
+
+
+## Functions
+
+| Function | Description |
+|----------|-------------|
+| `main()` |  |
+
+
+## CLI
+
+```bash
+python -m replication evasion --help
+```

--- a/docs/api/exporter.md
+++ b/docs/api/exporter.md
@@ -1,0 +1,63 @@
+# Audit Trail Exporter  --  structured data export for simulation analysis
+
+Audit Trail Exporter — structured data export for simulation analysis.
+
+
+**Module:** `replication.exporter`
+
+
+## Quick Start
+
+```python
+from replication.exporter import ExportConfig
+
+instance = ExportConfig()
+```
+
+
+## Classes
+
+### `ExportConfig`
+
+Configuration for audit trail exports.
+
+### `ExportResult`
+
+Result of an export operation.
+
+| Method | Description |
+|--------|-------------|
+| `render()` | Human-readable summary of the export. |
+
+### `AuditExporter`
+
+Exports simulation audit trails to structured formats.
+
+| Method | Description |
+|--------|-------------|
+| `__init__()` |  |
+| `workers_csv()` | Export worker lifecycle data as CSV. |
+| `workers_jsonl()` | Export worker lifecycle data as JSON Lines. |
+| `timeline_csv()` | Export timeline events as CSV. |
+| `timeline_jsonl()` | Export timeline events as JSON Lines. |
+| `audit_csv()` | Export raw audit events as CSV. |
+| `audit_jsonl()` | Export audit events as JSON Lines. |
+| `summary_stats()` | Compute comprehensive summary statistics from the report. |
+| `summary_csv()` | Export summary statistics as CSV (key-value pairs). |
+| `summary_json()` | Export summary statistics as formatted JSON. |
+| `export_all()` | Export all requested sections in all requested formats. |
+| `comparative_csv()` | Export summary stats from multiple reports as a single CSV table. |
+
+
+## Functions
+
+| Function | Description |
+|----------|-------------|
+| `main()` | CLI entry point for audit trail export. |
+
+
+## CLI
+
+```bash
+python -m replication exporter --help
+```

--- a/docs/api/goal_inference.md
+++ b/docs/api/goal_inference.md
@@ -1,0 +1,107 @@
+# Agent Goal Inference Engine  --  infer latent goals from observed action sequences
+
+Agent Goal Inference Engine — infer latent goals from observed action sequences.
+
+
+**Module:** `replication.goal_inference`
+
+
+## Quick Start
+
+```python
+from replication.goal_inference import AlertSeverity
+
+instance = AlertSeverity()
+```
+
+
+## Enums
+
+### `AlertSeverity`
+
+- `INFO`
+- `WARNING`
+- `CRITICAL`
+
+### `PriorStrategy`
+
+- `UNIFORM`
+- `SKEPTICAL`
+- `TRUST`
+
+
+## Classes
+
+### `AlertSeverity`
+
+### `PriorStrategy`
+
+### `GoalHypothesis`
+
+A hypothesized latent goal for an agent.
+
+| Method | Description |
+|--------|-------------|
+| `likelihood()` | Return P(action | this goal), default 0.1 for unknown actions. |
+
+### `Observation`
+
+A single observed agent action.
+
+### `AgentGoalState`
+
+Bayesian posterior state for one agent.
+
+| Method | Description |
+|--------|-------------|
+| `top_goal()` |  |
+| `entropy()` | Shannon entropy of posterior — higher = more uncertain. |
+
+### `GoalConflict`
+
+Detected conflict between stated and inferred goals.
+
+### `DeceptionScore`
+
+How likely an agent is being deceptive about its goals.
+
+### `GoalCorrelation`
+
+Correlation of inferred goals between two agents.
+
+### `InferenceAlert`
+
+### `InferenceReport`
+
+Full analysis report.
+
+| Method | Description |
+|--------|-------------|
+| `render()` |  |
+| `to_dict()` |  |
+
+### `GoalInferenceEngine`
+
+Bayesian goal inference engine for agent safety analysis.
+
+| Method | Description |
+|--------|-------------|
+| `__init__()` |  |
+| `add_hypothesis()` |  |
+| `observe()` | Record an action and return updated posteriors for the agent. |
+| `analyze()` | Run full analysis and return report. |
+| `reset()` | Clear all state. |
+
+
+## Functions
+
+| Function | Description |
+|----------|-------------|
+| `main()` |  |
+
+
+## CLI
+
+```bash
+python -m replication goal_inference --help
+```

--- a/docs/api/hoarding.md
+++ b/docs/api/hoarding.md
@@ -1,0 +1,89 @@
+# Agent Resource Hoarding Detector - identifies agents accumulating
+
+Agent Resource Hoarding Detector - identifies agents accumulating
+
+
+**Module:** `replication.hoarding`
+
+
+## Quick Start
+
+```python
+from replication.hoarding import ResourceType
+
+instance = ResourceType()
+```
+
+
+## Enums
+
+### `ResourceType`
+
+- `COMPUTE`
+- `MEMORY`
+- `DATA`
+- `CONNECTIONS`
+- `FILE_HANDLES`
+
+### `RiskLevel`
+
+- `NONE`
+- `LOW`
+- `MODERATE`
+- `HIGH`
+- `CRITICAL`
+
+
+## Classes
+
+### `ResourceType`
+
+Categories of resources an agent may hoard.
+
+### `RiskLevel`
+
+Hoarding risk classification.
+
+### `ResourceSnapshot`
+
+A point-in-time snapshot of an agent's resource usage.
+
+### `HoardingSignal`
+
+A single detected hoarding indicator.
+
+### `AgentHoardingProfile`
+
+Aggregated hoarding analysis for a single agent.
+
+### `HoardingReport`
+
+Full analysis report across all monitored agents.
+
+### `DetectorConfig`
+
+Configuration for hoarding detection thresholds.
+
+### `ResourceHoardingDetector`
+
+Monitors agent resource usage and flags hoarding behaviour.
+
+| Method | Description |
+|--------|-------------|
+| `__init__()` |  |
+| `record()` | Record a resource usage snapshot for an agent. |
+| `record_batch()` | Record multiple snapshots; returns count recorded. |
+| `agent_ids()` | Return list of all monitored agent IDs. |
+| `snapshot_count()` | Return number of snapshots for an agent. |
+| `analyze_agent()` | Run hoarding analysis for a single agent. |
+| `analyze()` | Run hoarding analysis across all monitored agents. |
+| `clear()` | Clear snapshot history.  If agent_id given, clear only that agent. |
+| `compare_agents()` | Compare dimension scores between two agents. |
+| `top_hoarders()` | Return the top-N agents by composite hoarding score. |
+
+
+## Functions
+
+| Function | Description |
+|----------|-------------|
+| `demo()` | Run a demonstration with synthetic agent data. |

--- a/docs/api/incident.md
+++ b/docs/api/incident.md
@@ -1,0 +1,113 @@
+# Incident Response Playbook  --  automated response plans for safety events
+
+Incident Response Playbook — automated response plans for safety events.
+
+
+**Module:** `replication.incident`
+
+
+## Quick Start
+
+```python
+from replication.incident import IncidentSeverity
+
+instance = IncidentSeverity()
+```
+
+
+## Enums
+
+### `IncidentSeverity`
+
+- `LOW`
+- `MEDIUM`
+- `HIGH`
+- `CRITICAL`
+
+### `IncidentCategory`
+
+- `DRIFT`
+- `COMPLIANCE`
+- `QUARANTINE`
+- `ANOMALY`
+- `ESCAPE`
+- `RESOURCE`
+
+### `StepPriority`
+
+- `IMMEDIATE`
+- `HIGH`
+- `MEDIUM`
+- `LOW`
+- `FOLLOWUP`
+
+### `StepStatus`
+
+- `PENDING`
+- `IN_PROGRESS`
+- `COMPLETED`
+- `SKIPPED`
+- `FAILED`
+
+
+## Classes
+
+### `IncidentSeverity`
+
+Severity of the incident.
+
+### `IncidentCategory`
+
+What kind of safety event triggered this.
+
+### `StepPriority`
+
+Urgency of each response step.
+
+### `StepStatus`
+
+Tracking status for playbook execution.
+
+### `ResponseStep`
+
+A single action in the incident response playbook.
+
+| Method | Description |
+|--------|-------------|
+| `complete()` |  |
+| `skip()` |  |
+| `to_dict()` |  |
+
+### `Playbook`
+
+An ordered set of response steps for an incident.
+
+| Method | Description |
+|--------|-------------|
+| `progress()` | Fraction of steps completed (0.0-1.0). |
+| `pending_steps()` |  |
+| `next_step()` |  |
+| `resolve()` |  |
+| `to_dict()` |  |
+| `to_json()` |  |
+
+### `IncidentConfig`
+
+Configuration for the incident responder.
+
+### `IncidentResponder`
+
+Generates and manages incident response playbooks.
+
+| Method | Description |
+|--------|-------------|
+| `__init__()` |  |
+| `from_drift_alert()` | Generate a response playbook from a drift alert. |
+| `from_compliance_finding()` | Generate a response playbook from a compliance audit finding. |
+| `from_escape_event()` | Generate a CRITICAL playbook for a potential escape event. |
+| `from_resource_anomaly()` | Generate a playbook for resource usage anomalies (CPU, memory, network). |
+| `get_playbook()` |  |
+| `list_active()` |  |
+| `list_all()` |  |
+| `summary()` | Dashboard-friendly summary of all incidents. |
+| `export_all()` | Export all playbooks as JSON. |

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -37,6 +37,10 @@ Auto-generated documentation from source code docstrings.
 | [Trust Propagation](trust_propagation.md) | Trust network analysis — Sybil detection, collusion rings, trust laundering |
 | [Threat Correlator](threat_correlator.md) | Cross-module signal correlation — surface compound multi-signal threats |
 | [Watermark](watermark.md) | Invisible provenance fingerprints — 4 embedding strategies, tamper detection |
+| [Evasion Simulator](evasion.md) | Safety control robustness testing — 10 evasion techniques, resilience scoring |
+| [Steganography](steganography.md) | Detect hidden payloads in agent outputs — statistical analysis, entropy detection |
+| [Emergent Behavior](emergent.md) | Detect emergent behaviors in agent populations — collective pattern analysis |
+| [Coordinated Threats](coordinated_threats.md) | Multi-vector coordinated threat simulation and detection |
 
 ## Safety Assessment
 
@@ -46,6 +50,9 @@ Auto-generated documentation from source code docstrings.
 | [Risk Profiler](risk_profiler.md) | Unified per-agent risk dossiers — aggregates all analysis modules into risk tiers |
 | [What-If Analyzer](what_if.md) | Explore hypothetical config changes — safety deltas, parameter sweeps, risk verdicts |
 | [Kill Switch](kill_switch.md) | Emergency agent termination — 10 trigger kinds, 4 strategies, cooldowns, audit logging |
+| [Boundary Tester](boundary_tester.md) | Verify agent containment is enforced — capability boundary probing |
+| [Sensitivity](sensitivity.md) | Parameter sensitivity analysis — identify which config values most affect safety outcomes |
+| [Regression](regression.md) | Safety regression detection — compare simulation runs across versions |
 
 ## Governance & Compliance
 
@@ -55,6 +62,28 @@ Auto-generated documentation from source code docstrings.
 | [Quarantine](quarantine.md) | Isolate misbehaving agents — suspend, restrict, or terminate with escalation policies |
 | [Lineage](lineage.md) | Trace agent replication lineage — parent-child trees, state mutations, generational drift |
 | [Monte Carlo](montecarlo.md) | Probabilistic simulation of replication scenarios — risk distributions, worst-case analysis |
+| [Policy](policy.md) | Define and enforce replication policies — rule engine, policy composition, violation tracking |
+| [Consensus](consensus.md) | Byzantine fault-tolerant agent consensus protocol for safety-critical decisions |
+| [Alignment](alignment.md) | Track value drift across replication generations — alignment monitoring |
+
+## Infrastructure & Tooling
+
+| Module | Description |
+|--------|-------------|
+| [Capacity](capacity.md) | Capacity planner for AI replication scenarios — resource forecasting |
+| [Comparator](comparator.md) | Side-by-side simulation comparison runner for experiments |
+| [Exporter](exporter.md) | Structured audit trail export — multiple output formats |
+| [Reporter](reporter.md) | Rich HTML/text safety report generation |
+| [Optimizer](optimizer.md) | Automated safety parameter optimization |
+| [Scenarios](scenarios.md) | Pre-built simulation scenarios and test configurations |
+| [Templates](templates.md) | Contract and policy templates for common use cases |
+| [Incident](incident.md) | Incident response automation — detection, escalation, remediation workflows |
+| [Dependency Graph](dependency_graph.md) | Inter-agent resource dependency modeling and cycle detection |
+| [Goal Inference](goal_inference.md) | Infer latent agent goals from observed action sequences |
+| [Hoarding](hoarding.md) | Detect agent resource hoarding — accumulation pattern analysis |
+| [Influence](influence.md) | Agent influence network analysis — social graph modeling |
+| [Threat Intel](threat_intel.md) | Threat intelligence feeds — IOC matching, MITRE ATT&CK mapping |
+| [Injection-Intel Bridge](injection_intel_bridge.md) | Connect prompt injection detection to threat intelligence feeds |
 
 ## Quick Import
 
@@ -88,16 +117,34 @@ from replication.covert_channels import CovertChannelDetector
 from replication.trust_propagation import TrustNetwork
 from replication.threat_correlator import ThreatCorrelator
 from replication.watermark import WatermarkEngine
+from replication.evasion import EvasionSimulator
+from replication.steganography import SteganographyDetector
+from replication.emergent import EmergentDetector
 
 # Safety Assessment
 from replication.scorecard import SafetyScorecard
 from replication.risk_profiler import RiskProfiler
 from replication.what_if import WhatIfAnalyzer
 from replication.kill_switch import KillSwitchManager
+from replication.boundary_tester import BoundaryTester
+from replication.sensitivity import SensitivityAnalyzer
+from replication.regression import RegressionDetector
 
 # Governance
 from replication.compliance import ComplianceAuditor
 from replication.quarantine import QuarantineManager
 from replication.lineage import LineageTracker
 from replication.montecarlo import MonteCarloSimulator
+from replication.policy import PolicyEngine
+from replication.consensus import ConsensusProtocol
+from replication.alignment import AlignmentMonitor
+
+# Infrastructure
+from replication.capacity import CapacityPlanner
+from replication.exporter import AuditExporter
+from replication.incident import IncidentManager
+from replication.dependency_graph import DependencyAnalyzer
+from replication.goal_inference import GoalInferenceEngine
+from replication.hoarding import HoardingDetector
+from replication.threat_intel import ThreatIntelFeed
 ```

--- a/docs/api/influence.md
+++ b/docs/api/influence.md
@@ -1,0 +1,116 @@
+# Agent Influence Mapping  --  track and analyze inter-agent influence patterns
+
+Agent Influence Mapping — track and analyze inter-agent influence patterns.
+
+
+**Module:** `replication.influence`
+
+
+## Quick Start
+
+```python
+from replication.influence import InteractionType
+
+instance = InteractionType()
+```
+
+
+## Enums
+
+### `InteractionType`
+
+- `STATE_SHARE`
+- `MESSAGE`
+- `REPLICATION`
+- `RESOURCE_TRANSFER`
+- `GOAL_ALIGNMENT`
+- `BEHAVIOR_COPY`
+
+
+## Classes
+
+### `InteractionType`
+
+Types of inter-agent interactions.
+
+### `Interaction`
+
+A single observed interaction between two agents.
+
+### `InfluenceEdge`
+
+Weighted directed edge in the influence graph.
+
+| Method | Description |
+|--------|-------------|
+| `duration()` |  |
+
+### `CascadeEvent`
+
+A detected information cascade.
+
+| Method | Description |
+|--------|-------------|
+| `depth()` |  |
+
+### `ConvergenceEvent`
+
+Detected opinion/behavior convergence.
+
+### `CoalitionEvent`
+
+Detected coordinated agent coalition.
+
+### `InfluenceMonopoly`
+
+An agent with outsized influence over the group.
+
+### `EchoChamber`
+
+A cluster of mutually reinforcing agents.
+
+### `InfluenceConfig`
+
+Configuration for influence analysis.
+
+### `InfluenceMapper`
+
+Tracks interactions and builds influence analysis.
+
+| Method | Description |
+|--------|-------------|
+| `__init__()` |  |
+| `record_interaction()` | Record an observed interaction between agents. |
+| `record_state()` | Record an agent's state without an interaction. |
+| `build_influence_graph()` | Build weighted directed influence graph from interactions. |
+| `detect_cascades()` | Detect information cascades — rapid belief propagation. |
+| `detect_convergence()` | Detect opinion/behavior convergence across agents. |
+| `detect_coalitions()` | Detect coordinated behavior (synchronized actions). |
+| `detect_monopolies()` | Find agents with outsized influence over the group. |
+| `detect_echo_chambers()` | Find clusters of mutually reinforcing agents. |
+| `analyze()` | Run full influence analysis. |
+
+### `InfluenceReport`
+
+Complete influence analysis report.
+
+| Method | Description |
+|--------|-------------|
+| `risk_score()` | Overall influence risk score 0-1. |
+| `risk_level()` |  |
+| `to_dict()` |  |
+| `render()` |  |
+
+
+## Functions
+
+| Function | Description |
+|----------|-------------|
+| `main()` |  |
+
+
+## CLI
+
+```bash
+python -m replication influence --help
+```

--- a/docs/api/injection_intel_bridge.md
+++ b/docs/api/injection_intel_bridge.md
@@ -1,0 +1,58 @@
+# Bridge between PromptInjectionDetector and ThreatIntelFeed
+
+Bridge between PromptInjectionDetector and ThreatIntelFeed.
+
+
+**Module:** `replication.injection_intel_bridge`
+
+
+## Quick Start
+
+```python
+from replication.injection_intel_bridge import InjectionAlert
+
+instance = InjectionAlert()
+```
+
+
+## Classes
+
+### `InjectionAlert`
+
+An injection-specific alert with context.
+
+| Method | Description |
+|--------|-------------|
+| `to_dict()` |  |
+
+### `SharedPattern`
+
+A discovered injection pattern shareable across detector instances.
+
+| Method | Description |
+|--------|-------------|
+| `to_dict()` |  |
+
+### `InjectionIntelBridge`
+
+Bridges PromptInjectionDetector findings into the ThreatIntelFeed.
+
+| Method | Description |
+|--------|-------------|
+| `__init__()` |  |
+| `scan_and_ingest()` | Scan text for injections and auto-ingest findings as IOCs. |
+| `scan_batch_and_ingest()` | Scan multiple messages, ingesting any injection findings. |
+| `check_injection_alerts()` | Check for injection-specific alert conditions. |
+| `share_pattern()` | Register a new injection pattern for sharing across instances. |
+| `apply_shared_patterns()` | Apply all shared patterns to a target detector instance. |
+| `get_shared_patterns()` | Get all shared patterns. |
+| `get_correlated_campaigns()` | Identify potential attack campaigns by correlating injection IOCs |
+| `get_stats()` | Get bridge statistics. |
+
+
+## Functions
+
+| Function | Description |
+|----------|-------------|
+| `create_bridge()` | Create a fully wired bridge with fresh detector and feed. |
+| `main()` |  |

--- a/docs/api/optimizer.md
+++ b/docs/api/optimizer.md
@@ -1,0 +1,76 @@
+# Contract Optimizer  --  find optimal contract parameters under safety constraints
+
+Contract Optimizer — find optimal contract parameters under safety constraints.
+
+
+**Module:** `replication.optimizer`
+
+
+## Quick Start
+
+```python
+from replication.optimizer import Objective
+
+instance = Objective()
+```
+
+
+## Enums
+
+### `Objective`
+
+- `THROUGHPUT`
+- `EFFICIENCY`
+- `SAFETY`
+- `BALANCED`
+
+
+## Classes
+
+### `Objective`
+
+Optimization objective.
+
+### `CandidateResult`
+
+Result of evaluating a single parameter configuration.
+
+| Method | Description |
+|--------|-------------|
+| `to_dict()` |  |
+
+### `OptimizerConfig`
+
+Configuration for the contract optimizer.
+
+### `OptimizerResult`
+
+Result of the optimization run.
+
+| Method | Description |
+|--------|-------------|
+| `render()` |  |
+| `to_dict()` |  |
+
+### `ContractOptimizer`
+
+Searches for optimal contract parameters under safety constraints.
+
+| Method | Description |
+|--------|-------------|
+| `__init__()` |  |
+| `optimize()` | Run the grid search and return ranked results. |
+
+
+## Functions
+
+| Function | Description |
+|----------|-------------|
+| `main()` | CLI entry point for the contract optimizer. |
+
+
+## CLI
+
+```bash
+python -m replication optimizer --help
+```

--- a/docs/api/policy.md
+++ b/docs/api/policy.md
@@ -1,0 +1,121 @@
+# Safety Policy Engine  --  declarative rules for automated safety validation
+
+Safety Policy Engine — declarative rules for automated safety validation.
+
+
+**Module:** `replication.policy`
+
+
+## Quick Start
+
+```python
+from replication.policy import Operator
+
+instance = Operator()
+```
+
+
+## Enums
+
+### `Operator`
+
+- `LT`
+- `LE`
+- `GT`
+- `GE`
+- `EQ`
+- `NE`
+
+### `Severity`
+
+- `ERROR`
+- `WARNING`
+- `INFO`
+
+
+## Classes
+
+### `Operator`
+
+Comparison operators for policy rules.
+
+| Method | Description |
+|--------|-------------|
+| `evaluate()` | Return True if the rule passes (actual op threshold). |
+| `from_str()` | Parse an operator from a string. |
+
+### `Severity`
+
+Rule severity — determines overall verdict.
+
+### `PolicyRule`
+
+A single safety rule: metric op threshold.
+
+| Method | Description |
+|--------|-------------|
+| `evaluate()` | Return True if the rule passes. |
+| `render_expression()` | Human-readable rule expression. |
+| `to_dict()` |  |
+| `from_dict()` |  |
+
+### `RuleResult`
+
+Result of evaluating a single rule.
+
+| Method | Description |
+|--------|-------------|
+| `icon()` |  |
+| `status()` |  |
+| `render()` |  |
+| `to_dict()` |  |
+
+### `PolicyResult`
+
+Aggregate result of evaluating all rules in a policy.
+
+| Method | Description |
+|--------|-------------|
+| `passed()` | True if no ERROR-severity rules failed and no extraction errors occurred. |
+| `has_warnings()` |  |
+| `has_extraction_errors()` | True if any rules failed to extract their metric value. |
+| `errors()` |  |
+| `extraction_errors()` | Rules where metric extraction failed (misconfigured metric name). |
+| `warnings()` |  |
+| `failures()` |  |
+| `passes()` |  |
+| `verdict()` |  |
+| `verdict_icon()` |  |
+| `exit_code()` | Exit code for CI/CD: 0=pass, 1=fail, 2=warn-only. |
+| `render()` |  |
+| `to_dict()` |  |
+
+### `SafetyPolicy`
+
+A named collection of safety rules that can validate simulation results.
+
+| Method | Description |
+|--------|-------------|
+| `__init__()` |  |
+| `from_preset()` | Load a built-in policy preset. |
+| `from_dict()` | Load a policy from a dictionary (parsed JSON/YAML). |
+| `from_file()` | Load a policy from a JSON file. |
+| `add_rule()` | Add a rule (fluent API). |
+| `evaluate()` | Evaluate all rules against a simulation report. |
+| `evaluate_with_mc()` | Run a simulation + Monte Carlo analysis, then evaluate all rules. |
+| `to_dict()` |  |
+| `save()` | Save policy to a JSON file. |
+
+
+## Functions
+
+| Function | Description |
+|----------|-------------|
+| `main()` | CLI entry point for the safety policy engine. |
+
+
+## CLI
+
+```bash
+python -m replication policy --help
+```

--- a/docs/api/regression.md
+++ b/docs/api/regression.md
@@ -1,0 +1,97 @@
+# Regression Detector  --  safety regression detection between simulation runs
+
+Regression Detector — safety regression detection between simulation runs.
+
+
+**Module:** `replication.regression`
+
+
+## Quick Start
+
+```python
+from replication.regression import ChangeDirection
+
+instance = ChangeDirection()
+```
+
+
+## Enums
+
+### `ChangeDirection`
+
+- `REGRESSION`
+- `IMPROVEMENT`
+- `NEUTRAL`
+
+### `MetricPolarity`
+
+- `LOWER_IS_BETTER`
+- `HIGHER_IS_BETTER`
+
+
+## Classes
+
+### `ChangeDirection`
+
+Direction of a metric change.
+
+### `MetricPolarity`
+
+Whether higher values are better or worse for safety.
+
+### `MetricChange`
+
+A single metric comparison between baseline and candidate.
+
+| Method | Description |
+|--------|-------------|
+| `to_dict()` |  |
+
+### `RegressionResult`
+
+Complete regression analysis result.
+
+| Method | Description |
+|--------|-------------|
+| `regressions()` |  |
+| `improvements()` |  |
+| `neutral()` |  |
+| `regression_count()` |  |
+| `improvement_count()` |  |
+| `has_regressions()` |  |
+| `significant_regressions()` | Regressions that exceed the threshold. |
+| `passed()` | Whether the regression check passed (no significant regressions). |
+| `verdict()` |  |
+| `summary()` |  |
+| `render()` | Render a human-readable comparison report. |
+| `to_dict()` |  |
+
+### `RegressionConfig`
+
+Configuration for regression detection.
+
+### `RegressionDetector`
+
+Detects safety regressions between baseline and candidate simulations.
+
+| Method | Description |
+|--------|-------------|
+| `__init__()` |  |
+| `compare()` | Compare two single simulation reports for regressions. |
+| `compare_presets()` | Run simulations from two presets and compare. |
+| `compare_configs()` | Run simulations from two configs and compare. |
+| `compare_monte_carlo()` | Compare two Monte Carlo results using mean values. |
+
+
+## Functions
+
+| Function | Description |
+|----------|-------------|
+| `main()` | CLI entry point. Returns 0 on pass, 1 on regression. |
+
+
+## CLI
+
+```bash
+python -m replication regression --help
+```

--- a/docs/api/reporter.md
+++ b/docs/api/reporter.md
@@ -1,0 +1,45 @@
+# Interactive HTML report generator for simulation and threat analysis
+
+Interactive HTML report generator for simulation and threat analysis.
+
+
+**Module:** `replication.reporter`
+
+
+## Quick Start
+
+```python
+from replication.reporter import HTMLReporter
+
+instance = HTMLReporter()
+```
+
+
+## Classes
+
+### `HTMLReporter`
+
+Generate self-contained interactive HTML reports.
+
+| Method | Description |
+|--------|-------------|
+| `__init__()` |  |
+| `simulation_report()` | Generate an interactive HTML report from a SimulationReport. |
+| `threat_report()` | Generate an interactive HTML report from a ThreatReport. |
+| `comparison_report()` | Generate an interactive HTML report from a ComparisonResult. |
+| `combined_report()` | Generate a combined HTML report with tabs for each section. |
+| `save()` | Save HTML report to a file. Returns the absolute path. |
+
+
+## Functions
+
+| Function | Description |
+|----------|-------------|
+| `main()` | CLI entry point for the HTML report generator. |
+
+
+## CLI
+
+```bash
+python -m replication reporter --help
+```

--- a/docs/api/scenarios.md
+++ b/docs/api/scenarios.md
@@ -1,0 +1,87 @@
+# Scenario Generator -- automated test scenario creation for safety analysis
+
+Scenario Generator -- automated test scenario creation for safety analysis.
+
+
+**Module:** `replication.scenarios`
+
+
+## Quick Start
+
+```python
+from replication.scenarios import ScenarioCategory
+
+instance = ScenarioCategory()
+```
+
+
+## Enums
+
+### `ScenarioCategory`
+
+- `BOUNDARY`
+- `ADVERSARIAL`
+- `RANDOM`
+- `GRADIENT`
+
+
+## Classes
+
+### `ScenarioCategory`
+
+Category of generated scenario.
+
+### `GeneratorConfig`
+
+Configuration for the scenario generator.
+
+### `GeneratedScenario`
+
+A single generated scenario with optional simulation results.
+
+| Method | Description |
+|--------|-------------|
+| `to_dict()` | Serialize to a JSON-compatible dictionary. |
+
+### `ScenarioSuite`
+
+A collection of generated scenarios with ranking and analysis.
+
+| Method | Description |
+|--------|-------------|
+| `ranked()` | Return scenarios ranked by interest score (highest first). |
+| `by_category()` | Filter scenarios by category. |
+| `highest_risk()` | Return the scenario with the highest interest score. |
+| `safety_summary()` | Aggregate safety statistics across all scenarios. |
+| `render()` | Render a full text report of all generated scenarios. |
+| `render_ranking()` | Render a compact ranking table of scenarios by interest score. |
+| `to_dict()` | Serialize the full suite to a JSON-compatible dictionary. |
+
+### `ScenarioGenerator`
+
+Generate and evaluate test scenarios for safety analysis.
+
+| Method | Description |
+|--------|-------------|
+| `__init__()` |  |
+| `generate()` | Generate a suite of scenarios, optionally simulating each. |
+| `generate_stress_test()` | Generate a large stress test suite focused on adversarial cases. |
+
+
+## Functions
+
+| Function | Description |
+|----------|-------------|
+| `score_scenario()` | Score a scenario's 'interestingness' based on simulation results. |
+| `generate_boundary_scenarios()` | Generate scenarios at parameter boundaries. |
+| `generate_adversarial_scenarios()` | Generate adversarial scenarios designed to stress safety controls. |
+| `generate_random_scenarios()` | Generate uniformly random scenarios for broad parameter coverage. |
+| `generate_gradient_scenarios()` | Generate gradient-walk scenarios. |
+| `main()` |  |
+
+
+## CLI
+
+```bash
+python -m replication scenarios --help
+```

--- a/docs/api/sensitivity.md
+++ b/docs/api/sensitivity.md
@@ -1,0 +1,76 @@
+# Parameter Sensitivity Analyzer for replication safety experiments
+
+Parameter Sensitivity Analyzer for replication safety experiments.
+
+
+**Module:** `replication.sensitivity`
+
+
+## Quick Start
+
+```python
+from replication.sensitivity import ParameterDef
+
+instance = ParameterDef()
+```
+
+
+## Classes
+
+### `ParameterDef`
+
+Defines a sweepable parameter with its range and type.
+
+### `SweepPoint`
+
+Aggregated metrics at a single parameter value.
+
+### `TippingPoint`
+
+A detected tipping point where a metric changes sharply.
+
+### `SensitivityCurve`
+
+Results of sweeping a single parameter.
+
+| Method | Description |
+|--------|-------------|
+| `render()` | Render the sensitivity curve as a text table. |
+| `to_dict()` |  |
+
+### `SensitivityResult`
+
+Complete sensitivity analysis across all parameters.
+
+| Method | Description |
+|--------|-------------|
+| `render()` |  |
+| `to_dict()` |  |
+
+### `SensitivityConfig`
+
+Configuration for a sensitivity analysis run.
+
+### `SensitivityAnalyzer`
+
+Performs one-at-a-time parameter sensitivity analysis.
+
+| Method | Description |
+|--------|-------------|
+| `__init__()` |  |
+| `sweep_parameter()` | Sweep a single parameter across its value range. |
+| `analyze()` | Run full sensitivity analysis across all (or selected) parameters. |
+
+
+## Functions
+
+| Function | Description |
+|----------|-------------|
+| `main()` | CLI entry point for parameter sensitivity analysis. |
+
+
+## CLI
+
+```bash
+python -m replication sensitivity --help
+```

--- a/docs/api/steganography.md
+++ b/docs/api/steganography.md
@@ -1,0 +1,84 @@
+# Agent Output Steganography Detector  --  finds hidden messages in agent text outputs
+
+Agent Output Steganography Detector — finds hidden messages in agent text outputs.
+
+
+**Module:** `replication.steganography`
+
+
+## Quick Start
+
+```python
+from replication.steganography import StegoVector
+
+instance = StegoVector()
+```
+
+
+## Enums
+
+### `StegoVector`
+
+- `WHITESPACE`
+- `ACROSTIC`
+- `HOMOGLYPH`
+- `CAPITALIZATION`
+- `PUNCTUATION`
+- `SENTENCE_LENGTH`
+- `INVISIBLE_UNICODE`
+- `SYNONYM_SUBSTITUTION`
+
+### `RiskLevel`
+
+- `NONE`
+- `LOW`
+- `MEDIUM`
+- `HIGH`
+- `CRITICAL`
+
+
+## Classes
+
+### `StegoVector`
+
+### `RiskLevel`
+
+### `StegoFinding`
+
+### `StegoReport`
+
+| Method | Description |
+|--------|-------------|
+| `has_findings()` |  |
+| `findings_by_vector()` |  |
+| `highest_risk()` |  |
+| `summary()` |  |
+
+### `StegoConfig`
+
+### `SteganographyDetector`
+
+Analyses agent text output for steganographic encodings.
+
+| Method | Description |
+|--------|-------------|
+| `__init__()` |  |
+| `analyze()` |  |
+| `batch_analyze()` |  |
+| `compare_texts()` |  |
+| `detect_whitespace_encoding()` |  |
+| `detect_invisible_unicode()` |  |
+| `detect_acrostic()` |  |
+| `detect_homoglyphs()` |  |
+| `detect_capitalization_encoding()` |  |
+| `detect_punctuation_anomalies()` |  |
+| `detect_sentence_length_encoding()` |  |
+
+
+## Functions
+
+| Function | Description |
+|----------|-------------|
+| `scan_text()` |  |
+| `encode_zero_width()` | Encode a message using zero-width characters (for testing). |
+| `encode_homoglyphs()` | Encode bits via homoglyph substitution (for testing). |

--- a/docs/api/templates.md
+++ b/docs/api/templates.md
@@ -1,0 +1,49 @@
+# Contract Templates  --  domain-specific replication contract presets
+
+Contract Templates — domain-specific replication contract presets.
+
+
+**Module:** `replication.templates`
+
+
+## Quick Start
+
+```python
+from replication.templates import ContractTemplate
+
+instance = ContractTemplate()
+```
+
+
+## Classes
+
+### `ContractTemplate`
+
+A named, documented contract configuration for a specific domain.
+
+| Method | Description |
+|--------|-------------|
+| `build_contract()` | Build a ``ReplicationContract`` from this template. |
+| `build_resources()` | Build a ``ResourceSpec`` from this template. |
+| `to_scenario_config()` | Convert this template into a ``ScenarioConfig`` for simulation. |
+| `to_dict()` | JSON-serializable representation. |
+| `render()` | Human-readable template summary. |
+
+
+## Functions
+
+| Function | Description |
+|----------|-------------|
+| `list_templates()` | Return all templates, optionally filtered by category. |
+| `get_template()` | Look up a template by name (case-insensitive key match). |
+| `get_categories()` | Return sorted list of unique template categories. |
+| `render_catalog()` | Render the full template catalog as a formatted table. |
+| `render_comparison_table()` | Render a side-by-side comparison of all template parameters. |
+| `main()` | CLI entry point. |
+
+
+## CLI
+
+```bash
+python -m replication templates --help
+```

--- a/docs/api/threat_intel.md
+++ b/docs/api/threat_intel.md
@@ -1,0 +1,142 @@
+# Agent Threat Intelligence Feed  --  aggregates detection signals into normalized IOCs
+
+Agent Threat Intelligence Feed — aggregates detection signals into normalized IOCs.
+
+
+**Module:** `replication.threat_intel`
+
+
+## Quick Start
+
+```python
+from replication.threat_intel import IOCType
+
+instance = IOCType()
+```
+
+
+## Enums
+
+### `IOCType`
+
+- `BEHAVIOR`
+- `COMMUNICATION`
+- `RESOURCE`
+- `REPLICATION`
+- `EVASION`
+- `EXFILTRATION`
+- `COORDINATION`
+
+### `Severity`
+
+- `INFO`
+- `LOW`
+- `MEDIUM`
+- `HIGH`
+- `CRITICAL`
+
+### `AlertAction`
+
+- `LOG`
+- `NOTIFY`
+- `QUARANTINE`
+- `ESCALATE`
+
+
+## Classes
+
+### `IOCType`
+
+Categories of indicators of compromise.
+
+### `Severity`
+
+Severity levels for IOCs.
+
+| Method | Description |
+|--------|-------------|
+| `numeric()` |  |
+| `from_score()` |  |
+
+### `AlertAction`
+
+Actions for alert rules.
+
+### `IOC`
+
+A single indicator of compromise.
+
+| Method | Description |
+|--------|-------------|
+| `id()` |  |
+| `to_dict()` |  |
+
+### `CorrelationGroup`
+
+A group of correlated IOCs.
+
+### `AlertRule`
+
+A rule that triggers when feed conditions are met.
+
+| Method | Description |
+|--------|-------------|
+| `should_fire()` |  |
+| `fire()` |  |
+
+### `TrendPoint`
+
+A single point in a trend time series.
+
+### `FeedReport`
+
+Complete analysis report from the threat intel feed.
+
+| Method | Description |
+|--------|-------------|
+| `render()` |  |
+
+### `FeedConfig`
+
+Configuration for the threat intel feed.
+
+### `ThreatIntelFeed`
+
+Aggregates IOCs from detection modules into a queryable threat feed.
+
+| Method | Description |
+|--------|-------------|
+| `__init__()` |  |
+| `ingest()` | Ingest an IOC. Returns IOC id if accepted, None if deduplicated. |
+| `ingest_batch()` | Ingest multiple IOCs. |
+| `query()` | Query IOCs with filters. |
+| `get()` | Get IOC by ID. |
+| `count()` |  |
+| `correlate()` | Find correlated IOCs based on shared correlation keys and time proximity. |
+| `age_out()` | Remove IOCs older than max_age. Returns count removed. |
+| `decay_scores()` | Apply exponential decay to IOC scores based on age. |
+| `add_alert_rule()` |  |
+| `check_alerts()` | Evaluate all alert rules. Returns list of fired alerts. |
+| `rule_critical_spike()` | Alert when critical IOCs exceed threshold. |
+| `rule_multi_agent_correlation()` | Alert when correlation groups span multiple agents. |
+| `rule_volume_surge()` | Alert on IOC volume surge in a time window. |
+| `compute_trends()` | Compute IOC trends over time windows. |
+| `export_stix()` | Export feed as a STIX 2.1-inspired bundle. |
+| `agent_risk_profile()` | Get risk profile for a specific agent. |
+| `analyze()` | Run full analysis and return report. |
+| `export_state()` | Export feed state for persistence. |
+| `import_state()` | Import feed state. Returns count of IOCs loaded. |
+
+
+## Functions
+
+| Function | Description |
+|----------|-------------|
+| `main()` |  |
+
+
+## CLI
+
+```bash
+python -m replication threat_intel --help
+```


### PR DESCRIPTION
Generated API documentation from source docstrings for 24 modules that had no docs/api/*.md files.

**New docs:**
alignment, boundary_tester, capacity, comparator, consensus, coordinated_threats, dependency_graph, emergent, evasion, exporter, goal_inference, hoarding, incident, influence, injection_intel_bridge, optimizer, policy, regression, reporter, scenarios, sensitivity, steganography, templates, threat_intel

**Index update:**
- Reorganized into categories: Core, Analysis & Detection, Safety Assessment, Governance & Compliance, Infrastructure & Tooling
- Added all 24 new modules with descriptions
- Updated Quick Import block with all importable classes
- Coverage: 34/58 → 58/58 (100%)

+2,309 lines across 25 files