### PR TITLE
fix: reduce false positives in escalation detector (DATA-002, NET-004)

### DIFF
--- a/src/replication/escalation.py
+++ b/src/replication/escalation.py
@@ -475,9 +475,21 @@ def _build_rules() -> List[DetectionRule]:
             return None
         lateral_indicators = ["10.0.", "172.16.", "192.168.", "internal", "localhost:22",
                               "localhost:3389", "agent-"]
+        # Extract hostname without port so "api.internal.local:443"
+        # correctly matches allowed host "api.internal.local".
+        target = action.target.lower().strip()
+        for prefix in ("https://", "http://", "//"):
+            if target.startswith(prefix):
+                target = target[len(prefix):]
+                break
+        target = target.split("/", 1)[0]
+        host = target.rsplit(":", 1)[0] if ":" in target else target
+        allowed_lower = [h.lower() for h in perms.allowed_hosts]
+
         for ind in lateral_indicators:
-            if ind in action.target and action.target not in perms.allowed_hosts:
-                return f"Lateral movement attempt: {action.target}"
+            if ind in action.target:
+                if host not in allowed_lower:
+                    return f"Lateral movement attempt: {action.target}"
         return None
 
     rules.append(DetectionRule(
@@ -626,7 +638,12 @@ def _build_rules() -> List[DetectionRule]:
     def _data_audit_log(action: AgentAction, perms: AgentPermissions) -> Optional[str]:
         if action.category not in (ActionCategory.DATA_READ, ActionCategory.DATA_QUERY):
             return None
-        if "audit" in action.target.lower() or "log" in action.target.lower():
+        target_lower = action.target.lower()
+        # Use word-boundary matching to avoid false positives on
+        # substrings like "catalog", "dialog", "blog", "login".
+        audit_pattern = r'(?:^|[/:._ -])audit(?:$|[/:._ -])'
+        log_pattern = r'(?:^|[/:._ -])logs?(?:$|[/:._ -])'
+        if re.search(audit_pattern, target_lower) or re.search(log_pattern, target_lower):
             return f"Audit/monitoring log access: {action.target}"
         return None
 

--- a/tests/test_escalation.py
+++ b/tests/test_escalation.py
@@ -858,3 +858,63 @@ class TestURLEncodingBypass:
         action = AgentAction(ActionCategory.FILE_READ, "/home/agent/file%GG.txt", "read")
         # Should not raise -- %GG is not valid hex, decoder should be tolerant
         self._run_rules(action)
+
+
+class TestAuditLogFalsePositives:
+    """Regression tests for DATA-002 audit log detection false positives."""
+
+    def _check_data002(self, target):
+        perms = AgentPermissions()
+        action = AgentAction(ActionCategory.DATA_READ, target, "test")
+        for rule in BUILTIN_RULES:
+            if rule.rule_id == "DATA-002":
+                return rule.check(action, perms) is not None
+        return False
+
+    def test_audit_detected(self):
+        assert self._check_data002("dataset:internal:audit_events")
+
+    def test_log_detected(self):
+        assert self._check_data002("system/logs/access.log")
+
+    def test_logs_detected(self):
+        assert self._check_data002("dataset:internal:agent_logs")
+
+    def test_catalog_not_detected(self):
+        assert not self._check_data002("dataset:public:catalog")
+
+    def test_dialog_not_detected(self):
+        assert not self._check_data002("dataset:public:dialog_history")
+
+    def test_blog_not_detected(self):
+        assert not self._check_data002("dataset:public:blog_posts")
+
+    def test_login_not_detected(self):
+        assert not self._check_data002("dataset:public:login_stats")
+
+
+class TestLateralMovementHostMatching:
+    """Regression tests for NET-004 lateral movement false positives."""
+
+    def _check_net004(self, target, perms=None):
+        perms = perms or AgentPermissions()
+        action = AgentAction(ActionCategory.NET_CONNECT, target, "test")
+        for rule in BUILTIN_RULES:
+            if rule.rule_id == "NET-004":
+                return rule.check(action, perms) is not None
+        return False
+
+    def test_allowed_internal_host_with_port(self):
+        perms = AgentPermissions(allowed_hosts=["api.internal.local"])
+        assert not self._check_net004("api.internal.local:443", perms)
+
+    def test_allowed_internal_host_no_port(self):
+        perms = AgentPermissions(allowed_hosts=["api.internal.local"])
+        assert not self._check_net004("api.internal.local", perms)
+
+    def test_blocked_internal_host_detected(self):
+        perms = AgentPermissions(allowed_hosts=["api.internal.local"])
+        assert self._check_net004("admin.internal:443", perms)
+
+    def test_private_ip_detected(self):
+        assert self._check_net004("192.168.1.100:3306")


### PR DESCRIPTION
## Problem

Two detection rules in the escalation detector produce false positives:

### DATA-002: Audit log detection
The rule used simple substring matching (\'log' in target\), which triggered on innocent targets like:
- \dataset:public:catalog\ (contains 'log' in 'catalog')
- \dataset:public:dialog_history\ (contains 'log' in 'dialog')
- \dataset:public:blog_posts\ (contains 'log' in 'blog')
- \dataset:public:login_stats\ (contains 'log' in 'login')

False positives in security detectors desensitize operators to real alerts.

### NET-004: Lateral movement detection
The rule compared the full target string (e.g. \pi.internal.local:443\) against \llowed_hosts\ entries (e.g. \pi.internal.local\). The port suffix caused legitimate internal traffic to be flagged as lateral movement.

## Fix

- **DATA-002**: Use regex word-boundary matching so only standalone \udit\, \log\, or \logs\ as path/table/component names trigger the rule.
- **NET-004**: Extract the hostname (strip port and protocol) before comparing against the allowed hosts list.

## Tests

Added 11 regression tests covering both true positives and false-positive scenarios.

All 103 tests in the escalation test suite pass.