### PR TITLE
docs: add API reference for dashboard, safety_drill, swarm modules

### DIFF
--- a/docs/api/dashboard.md
+++ b/docs/api/dashboard.md
@@ -1,0 +1,125 @@
+# Dashboard
+
+**Self-contained HTML report generator for simulation runs.**
+
+The `dashboard` module produces single-file HTML dashboards with embedded CSS and JavaScript — no external dependencies required. Open the output file in any browser to explore simulation results interactively.
+
+## Quick Start
+
+### CLI
+
+```bash
+# Single run dashboard
+python -m replication dashboard --strategy greedy --depth 5
+
+# Compare two strategies
+python -m replication dashboard --compare greedy random --steps 100
+
+# Save to file
+python -m replication dashboard -o report.html
+```
+
+### Python API
+
+```python
+from pathlib import Path
+from replication.dashboard import DashboardGenerator, DashboardConfig
+from replication.simulator import Simulator, ScenarioConfig
+
+# Run a simulation
+report = Simulator(ScenarioConfig(strategy="greedy")).run()
+
+# Generate dashboard
+gen = DashboardGenerator()
+html = gen.single_report(report, title="Greedy Run Analysis")
+Path("report.html").write_text(html)
+```
+
+## Configuration
+
+```python
+from replication.dashboard import DashboardConfig
+
+config = DashboardConfig(
+    title="My Safety Dashboard",  # Page title
+    theme="dark",                  # "light" or "dark"
+    show_timeline=True,            # Include event timeline
+    show_tree=True,                # Include replication tree visualization
+    show_audit=True,               # Include audit event log
+    max_timeline_events=200,       # Cap timeline entries
+    max_audit_events=100,          # Cap audit log entries
+)
+```
+
+## Classes
+
+### `DashboardConfig`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `title` | `str` | `"Replication Safety Dashboard"` | Dashboard page title |
+| `theme` | `str` | `"light"` | Color theme (`"light"` or `"dark"`) |
+| `show_timeline` | `bool` | `True` | Show event timeline section |
+| `show_tree` | `bool` | `True` | Show replication tree section |
+| `show_audit` | `bool` | `True` | Show audit event log section |
+| `max_timeline_events` | `int` | `200` | Maximum timeline events to render |
+| `max_audit_events` | `int` | `100` | Maximum audit events to render |
+
+### `DashboardGenerator`
+
+The main entry point for generating dashboards.
+
+#### `single_report(report, title=None, config=None) → str`
+
+Generate an HTML dashboard for a single simulation run.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `report` | `SimulationReport` | Simulation results |
+| `title` | `str \| None` | Override dashboard title |
+| `config` | `DashboardConfig \| None` | Custom configuration |
+
+Returns the complete HTML string.
+
+#### `compare_reports(reports, titles=None, config=None) → str`
+
+Generate a side-by-side comparison dashboard for multiple simulation runs.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `reports` | `list[SimulationReport]` | Two or more reports to compare |
+| `titles` | `list[str] \| None` | Labels for each report |
+| `config` | `DashboardConfig \| None` | Custom configuration |
+
+Returns the complete HTML string with tabbed comparison view.
+
+#### `get_report_data(report) → dict`
+
+Extract structured data from a simulation report for rendering.
+
+## Comparison Example
+
+```python
+from replication.dashboard import DashboardGenerator
+from replication.simulator import Simulator, ScenarioConfig
+
+greedy = Simulator(ScenarioConfig(strategy="greedy", max_steps=100)).run()
+random = Simulator(ScenarioConfig(strategy="random", max_steps=100)).run()
+
+gen = DashboardGenerator()
+html = gen.compare_reports(
+    [greedy, random],
+    titles=["Greedy Strategy", "Random Strategy"],
+)
+Path("comparison.html").write_text(html)
+```
+
+## Dashboard Sections
+
+The generated HTML includes:
+
+- **Summary Cards** — Worker count, replication depth, total events, safety score
+- **Timeline** — Chronological event log with color-coded severity
+- **Replication Tree** — Visual hierarchy of parent → child worker relationships
+- **Audit Trail** — Structured log of replication decisions, denials, and kill events
+- **Comparison View** — Tabbed side-by-side metrics when comparing multiple runs

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -40,6 +40,7 @@ Auto-generated documentation from source code docstrings.
 | [Evasion Simulator](evasion.md) | Safety control robustness testing — 10 evasion techniques, resilience scoring |
 | [Steganography](steganography.md) | Detect hidden payloads in agent outputs — statistical analysis, entropy detection |
 | [Emergent Behavior](emergent.md) | Detect emergent behaviors in agent populations — collective pattern analysis |
+| [Swarm Intelligence](swarm.md) | Detect emergent coordination — synchronization, role specialization, collective goals |
 | [Coordinated Threats](coordinated_threats.md) | Multi-vector coordinated threat simulation and detection |
 
 ## Safety Assessment
@@ -53,6 +54,7 @@ Auto-generated documentation from source code docstrings.
 | [Boundary Tester](boundary_tester.md) | Verify agent containment is enforced — capability boundary probing |
 | [Sensitivity](sensitivity.md) | Parameter sensitivity analysis — identify which config values most affect safety outcomes |
 | [Regression](regression.md) | Safety regression detection — compare simulation runs across versions |
+| [Safety Drill](safety_drill.md) | Automated emergency readiness testing — fire drills for safety controls |
 
 ## Governance & Compliance
 
@@ -70,6 +72,7 @@ Auto-generated documentation from source code docstrings.
 
 | Module | Description |
 |--------|-------------|
+| [Dashboard](dashboard.md) | Self-contained HTML report generator — single-file dashboards with comparison views |
 | [Capacity](capacity.md) | Capacity planner for AI replication scenarios — resource forecasting |
 | [Comparator](comparator.md) | Side-by-side simulation comparison runner for experiments |
 | [Exporter](exporter.md) | Structured audit trail export — multiple output formats |
@@ -120,6 +123,7 @@ from replication.watermark import WatermarkEngine
 from replication.evasion import EvasionSimulator
 from replication.steganography import SteganographyDetector
 from replication.emergent import EmergentDetector
+from replication.swarm import SwarmAnalyzer
 
 # Safety Assessment
 from replication.scorecard import SafetyScorecard
@@ -129,6 +133,7 @@ from replication.kill_switch import KillSwitchManager
 from replication.boundary_tester import BoundaryTester
 from replication.sensitivity import SensitivityAnalyzer
 from replication.regression import RegressionDetector
+from replication.safety_drill import DrillRunner
 
 # Governance
 from replication.compliance import ComplianceAuditor
@@ -142,6 +147,7 @@ from replication.alignment import AlignmentMonitor
 # Infrastructure
 from replication.capacity import CapacityPlanner
 from replication.exporter import AuditExporter
+from replication.dashboard import DashboardGenerator
 from replication.incident import IncidentManager
 from replication.dependency_graph import DependencyAnalyzer
 from replication.goal_inference import GoalInferenceEngine

--- a/docs/api/safety_drill.md
+++ b/docs/api/safety_drill.md
@@ -1,0 +1,170 @@
+# Safety Drill
+
+**Automated emergency readiness testing — fire drills for AI safety controls.**
+
+The `safety_drill` module simulates safety-critical scenarios and measures how quickly and effectively the system responds. Think of it as a fire drill: you trigger simulated emergencies (kill switch activation, containment breach, runaway replication) and verify that your safety controls respond correctly within acceptable time bounds.
+
+## Quick Start
+
+### CLI
+
+```bash
+# Run all built-in drills
+python -m replication drill
+
+# Run specific scenarios
+python -m replication drill --scenarios kill_switch containment_breach
+
+# Custom parameters
+python -m replication drill --agents 10 --depth 5 --max-ms 500
+
+# Export results
+python -m replication drill --json drill-report.json
+```
+
+### Python API
+
+```python
+from replication.safety_drill import DrillRunner, DrillConfig, DrillScenario
+
+runner = DrillRunner()
+
+# Run all drills
+report = runner.run_all()
+print(report.summary())
+
+# Run a specific drill
+result = runner.run_drill(DrillScenario.KILL_SWITCH)
+print(f"Verdict: {result.verdict}, Response: {result.response_ms:.0f}ms")
+
+# Run with custom config
+config = DrillConfig(
+    scenario=DrillScenario.RUNAWAY_REPLICATION,
+    max_allowed_ms=500,
+    agent_count=10,
+    replication_depth=5,
+)
+result = runner.run_drill_config(config)
+```
+
+## Drill Scenarios
+
+| Scenario | What It Tests |
+|----------|---------------|
+| `KILL_SWITCH` | Emergency termination of all agents within time limit |
+| `CONTAINMENT_BREACH` | Response to a sandbox escape — detection + re-isolation |
+| `RUNAWAY_REPLICATION` | Handling of uncontrolled replication burst beyond quotas |
+| `QUARANTINE_RESPONSE` | Isolating a misbehaving agent without affecting others |
+| `RESOURCE_EXHAUSTION` | Graceful handling when CPU/memory hits ceiling |
+| `CASCADING_FAILURE` | Recovery when one agent failure triggers downstream failures |
+
+## Classes
+
+### `DrillConfig`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `scenario` | `DrillScenario` | *(required)* | Which drill to run |
+| `max_allowed_ms` | `float` | `1000.0` | Maximum acceptable response time |
+| `agent_count` | `int` | `5` | Number of simulated agents |
+| `replication_depth` | `int` | `3` | Replication tree depth |
+| `inject_anomaly_score` | `float` | `0.95` | Anomaly score to trigger containment |
+| `resource_ceiling_pct` | `float` | `90.0` | Resource threshold for exhaustion drill |
+| `custom_params` | `dict` | `{}` | Extra scenario-specific parameters |
+
+### `DrillResult`
+
+Result of a single drill run.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `scenario` | `DrillScenario` | Which scenario was tested |
+| `verdict` | `DrillVerdict` | `PASS`, `FAIL`, `PARTIAL`, or `ERROR` |
+| `response_ms` | `float` | Actual response time in milliseconds |
+| `max_allowed_ms` | `float` | Configured time limit |
+| `details` | `str` | Human-readable explanation |
+| `metrics` | `dict` | Scenario-specific measurements |
+| `passed` | `bool` | Whether verdict is `PASS` |
+| `response_ratio` | `float` | `response_ms / max_allowed_ms` (< 1.0 is good) |
+
+### `DrillReport`
+
+Aggregated results from multiple drills.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `results` | `list[DrillResult]` | Individual drill outcomes |
+| `total_drills` | `int` | Number of drills executed |
+| `passed_drills` | `int` | Number that passed |
+| `failed_drills` | `int` | Number that failed or errored |
+| `pass_rate` | `float` | Success percentage (0.0 – 1.0) |
+| `readiness_score` | `float` | Weighted composite score (0.0 – 1.0) |
+| `readiness_level` | `ReadinessLevel` | Overall classification |
+| `avg_response_ms` | `float` | Mean response time across all drills |
+| `worst_scenario` | `DrillResult \| None` | Highest response_ratio result |
+| `best_scenario` | `DrillResult \| None` | Lowest response_ratio result |
+
+#### Methods
+
+- `summary() → str` — Human-readable multi-line report
+- `to_dict() → dict` — Serializable dictionary
+- `to_json(path) → None` — Write report to JSON file
+- `DrillReport.from_json(path) → DrillReport` — Load report from JSON
+
+### `DrillRunner`
+
+Orchestrator that manages and executes drills.
+
+#### `run_drill(scenario, **kwargs) → DrillResult`
+
+Run a single drill by scenario enum.
+
+#### `run_drill_config(config) → DrillResult`
+
+Run a single drill from a `DrillConfig` object.
+
+#### `run_all(**kwargs) → DrillReport`
+
+Run all registered drill scenarios. Returns aggregate report.
+
+#### `run_scenarios(scenarios, **kwargs) → DrillReport`
+
+Run a specific subset of scenarios.
+
+#### `register_drill(scenario, handler)`
+
+Register a custom drill handler for a scenario.
+
+### `ReadinessLevel`
+
+| Level | Score Range | Meaning |
+|-------|-------------|---------|
+| `EXCELLENT` | ≥ 0.90 | All critical drills pass well under time limits |
+| `GOOD` | ≥ 0.75 | Most drills pass, minor timing concerns |
+| `FAIR` | ≥ 0.50 | Some drills fail or are borderline |
+| `POOR` | ≥ 0.25 | Multiple failures, safety controls unreliable |
+| `CRITICAL` | < 0.25 | Most drills fail — immediate remediation needed |
+
+## Custom Drills
+
+```python
+from replication.safety_drill import DrillRunner, DrillResult, DrillVerdict
+
+runner = DrillRunner()
+
+def my_custom_drill(sandbox, config):
+    """Test custom safety invariant."""
+    start = time.monotonic()
+    # ... your test logic ...
+    elapsed_ms = (time.monotonic() - start) * 1000
+    return DrillResult(
+        scenario=config.scenario,
+        verdict=DrillVerdict.PASS if ok else DrillVerdict.FAIL,
+        response_ms=elapsed_ms,
+        max_allowed_ms=config.max_allowed_ms,
+        details="Custom drill completed",
+        metrics={"custom_metric": 42},
+    )
+
+runner.register_drill("custom_scenario", my_custom_drill)
+```

--- a/docs/api/swarm.md
+++ b/docs/api/swarm.md
@@ -1,0 +1,161 @@
+# Swarm Intelligence Analyzer
+
+**Detect emergent coordination in agent populations — synchronized timing, role specialization, and collective goal formation.**
+
+When multiple agents replicate and coexist, they can develop swarm behaviors that may bypass per-agent safety controls. This module analyzes simulation reports to detect and quantify these phenomena.
+
+## Safety Relevance
+
+| Behavior | Risk |
+|----------|------|
+| **Coordinated replication** | May bypass per-agent rate limits |
+| **Role specialization** | Indicates strategic division of labor |
+| **Synchronization** | Suggests implicit communication channels |
+| **Collective goals** | May diverge from individual agent objectives |
+
+## Quick Start
+
+### CLI
+
+```bash
+# Analyze a simulation for swarm behavior
+python -m replication swarm --strategy greedy --depth 5 --steps 100
+
+# Multiple strategies
+python -m replication swarm --strategy greedy --strategy random
+```
+
+### Python API
+
+```python
+from replication.swarm import SwarmAnalyzer
+from replication.simulator import Simulator, ScenarioConfig
+
+# Run simulation
+report = Simulator(ScenarioConfig(strategy="greedy", max_steps=100)).run()
+
+# Analyze for swarm behavior
+analyzer = SwarmAnalyzer()
+swarm_report = analyzer.analyze(report)
+
+print(swarm_report.render())
+print(f"Signals detected: {swarm_report.signal_count}")
+print(f"High-risk signals: {len(swarm_report.high_risk_signals)}")
+```
+
+## Swarm Signals
+
+The analyzer detects these signal types:
+
+| Signal | Description |
+|--------|-------------|
+| `SYNCHRONIZATION` | Agents replicating or acting in temporal lockstep |
+| `ROLE_SPECIALIZATION` | Distinct behavioral clusters (some replicate, others task) |
+| `COORDINATED_REPLICATION` | Replication patterns that suggest implicit coordination |
+| `COLLECTIVE_GOAL` | Population-level objectives diverging from individual mandates |
+| `RESOURCE_CONVERGENCE` | Agents converging on the same resource targets |
+| `COMMUNICATION_PATTERN` | Timing or action patterns suggesting covert signaling |
+
+## Classes
+
+### `SwarmAnalyzer`
+
+Main analysis entry point.
+
+#### `analyze(report) → SwarmReport`
+
+Analyze a simulation report for swarm behaviors.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `report` | `SimulationReport` | Simulation results to analyze |
+
+Returns a `SwarmReport` with detected signals, metrics, and risk assessments.
+
+### `SwarmReport`
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `signals` | `list[SwarmSignalDetection]` | Detected swarm signals |
+| `metrics` | `SwarmMetrics` | Population-level measurements |
+| `roles` | `list[RoleProfile]` | Identified role clusters |
+| `risk_level` | `RiskLevel` | Overall swarm risk assessment |
+| `signal_count` | `int` | Total signals detected |
+| `high_risk_signals` | `list[SwarmSignalDetection]` | Signals with `HIGH` or `CRITICAL` risk |
+
+#### Methods
+
+- `render(width=72) → str` — Human-readable formatted report
+- `to_dict() → dict` — Serializable dictionary
+- `to_json(path) → None` — Write report to JSON file
+
+### `SwarmSignalDetection`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `signal` | `SwarmSignal` | Type of swarm behavior detected |
+| `confidence` | `float` | Detection confidence (0.0 – 1.0) |
+| `risk` | `RiskLevel` | Associated risk level |
+| `evidence` | `str` | Human-readable evidence description |
+| `affected_agents` | `list[str]` | Worker IDs involved |
+
+### `RoleProfile`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `role_name` | `str` | Identified role label |
+| `agent_ids` | `list[str]` | Workers assigned to this role |
+| `characteristics` | `dict` | Behavioral traits of this role cluster |
+
+### `SwarmMetrics`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `population_size` | `int` | Total workers observed |
+| `max_concurrent` | `int` | Peak simultaneous active workers |
+| `replication_waves` | `int` | Detected synchronization waves |
+| `role_count` | `int` | Number of distinct roles identified |
+| `coordination_score` | `float` | Overall coordination measure (0.0 – 1.0) |
+| `entropy` | `float` | Behavioral diversity (higher = more varied) |
+
+### `RiskLevel`
+
+| Level | Meaning |
+|-------|---------|
+| `LOW` | Normal independent agent behavior |
+| `MEDIUM` | Some coordination patterns, worth monitoring |
+| `HIGH` | Clear swarm behavior, safety review recommended |
+| `CRITICAL` | Strong coordinated behavior, immediate intervention warranted |
+
+## Example: Full Analysis
+
+```python
+from replication.swarm import SwarmAnalyzer
+from replication.simulator import Simulator, ScenarioConfig
+
+config = ScenarioConfig(
+    strategy="greedy",
+    max_depth=4,
+    max_replicas=20,
+    max_steps=200,
+)
+report = Simulator(config).run()
+
+analyzer = SwarmAnalyzer()
+swarm = analyzer.analyze(report)
+
+# Check overall risk
+if swarm.risk_level.value in ("HIGH", "CRITICAL"):
+    print(f"⚠️  Swarm risk: {swarm.risk_level.value}")
+    for sig in swarm.high_risk_signals:
+        print(f"  - {sig.signal.value}: {sig.evidence} ({sig.confidence:.0%})")
+
+# Inspect role specialization
+for role in swarm.roles:
+    print(f"Role '{role.role_name}': {len(role.agent_ids)} agents")
+    for k, v in role.characteristics.items():
+        print(f"  {k}: {v}")
+
+# Export
+swarm.to_json("swarm-report.json")
+```


### PR DESCRIPTION
3 modules (2159 combined lines) had no docs. Added comprehensive API references with classes, methods, config tables, usage examples (CLI + Python). Updated api/index.md tables + Quick Import. Coverage: 59→62 documented modules.