### PR TITLE
security: replace hardcoded default watermark secret with per-instance random key

### DIFF
--- a/src/replication/game_theory.py
+++ b/src/replication/game_theory.py
@@ -436,7 +436,7 @@ def _generous_tft(history: List[Move], forgiveness: float = 0.1) -> Move:
         return Move.COOPERATE
     if history[-1] == Move.DEFECT:
         # Deterministic check based on round count for reproducibility
-        h = int(hashlib.md5(str(len(history)).encode()).hexdigest()[:8], 16)
+        h = int(hashlib.sha256(str(len(history)).encode()).hexdigest()[:8], 16)
         if (h % 1000) / 1000.0 < forgiveness:
             return Move.COOPERATE
         return Move.DEFECT
@@ -1028,7 +1028,7 @@ class GameTheoryAnalyzer:
                 )
             # RANDOM / UNKNOWN: alternate with hash for determinism
             h = int(
-                hashlib.md5(
+                hashlib.sha256(
                     f"{len(my_history)}".encode()
                 ).hexdigest()[:8],
                 16,

--- a/src/replication/watermark.py
+++ b/src/replication/watermark.py
@@ -60,9 +60,11 @@ import enum
 import hashlib
 import hmac
 import json
+import secrets
 import struct
 import sys
 import time
+import warnings
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -184,11 +186,32 @@ class RobustnessResult:
 
 @dataclass
 class WatermarkConfig:
-    """Configuration for the watermark engine."""
-    secret: str = "default-watermark-secret"
+    """Configuration for the watermark engine.
+
+    .. warning::
+
+        If *secret* is not supplied, a random 32-byte hex token is generated
+        per instance.  This is safe for single-process usage but means
+        watermarks cannot be verified across restarts or processes unless you
+        persist and reuse the same secret.
+    """
+
+    secret: str = ""
     strategies: Optional[List[WatermarkStrategy]] = None
     epsilon: float = _EPSILON
     max_bits_per_strategy: int = _MAX_BITS
+
+    def __post_init__(self) -> None:
+        if not self.secret:
+            self.secret = secrets.token_hex(32)
+            warnings.warn(
+                "WatermarkConfig instantiated without an explicit secret — "
+                "a random key was generated.  Watermarks signed with this "
+                "key cannot be verified after process restart.  Pass a "
+                "persistent secret for production use.",
+                UserWarning,
+                stacklevel=2,
+            )
 
 
 @dataclass

--- a/tests/test_watermark.py
+++ b/tests/test_watermark.py
@@ -1,7 +1,8 @@
-"""Tests for replication.watermark — agent state watermarking."""
+"""Tests for replication.watermark - agent state watermarking."""
 
 import json
 import time
+import warnings
 
 import pytest
 
@@ -368,7 +369,7 @@ class TestKeyOrdering:
             sample_state, worker_id="w-1", depth=1, timestamp=1000.0,
         )
         result = engine.verify(wm, receipt.fingerprint)
-        # Key ordering is inherently fragile — just check we get some bits
+        # Key ordering is inherently fragile - just check we get some bits
         assert result.bits_recovered > 0
 
 
@@ -525,10 +526,21 @@ class TestHistory:
 
 class TestConfig:
 
-    def test_default_config(self):
-        engine = WatermarkEngine()
-        assert engine.config.secret == "default-watermark-secret"
+    def test_default_config_generates_random_secret(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            engine = WatermarkEngine()
+        # Should be a random hex string, not the old hardcoded default
+        assert engine.config.secret != ""
+        assert engine.config.secret != "default-watermark-secret"
+        assert len(engine.config.secret) == 64  # 32 bytes = 64 hex chars
         assert engine.config.epsilon == 1e-10
+
+    def test_default_config_emits_warning(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            WatermarkEngine()
+            assert any("random key was generated" in str(x.message) for x in w)
 
     def test_custom_secret(self, sample_state):
         e1 = WatermarkEngine(WatermarkConfig(secret="secret-A"))


### PR DESCRIPTION
**Problem:** \WatermarkConfig\ defaulted to \secret='default-watermark-secret'\ — a publicly-known HMAC key. Any user who didn't override this got trivially forgeable watermarks.

**Fix:**
- Default secret is now empty; \__post_init__\ generates a cryptographically secure 32-byte hex token via \secrets.token_hex(32)\
- Emits \UserWarning\ so users know they should persist a secret for cross-process verification
- Replaced \hashlib.md5\ with \hashlib.sha256\ in \game_theory.py\ (MD5 deprecated, flags in security audits)

**Tests:** Updated to verify random key generation and warning emission. All 128 tests pass.