### PR TITLE
fix: per-agent breach tracking in KillSwitch (closes #60)

### DIFF
--- a/src/replication/kill_switch.py
+++ b/src/replication/kill_switch.py
@@ -120,16 +120,24 @@ class TriggerCondition:
     enabled: bool = True
     custom_fn: Optional[Callable[[Dict[str, Any]], bool]] = None
 
-    # Internal tracking for sustained triggers
-    _first_breach: Optional[float] = field(default=None, repr=False)
+    # Internal tracking for sustained triggers — keyed by agent_id so that
+    # resetting one agent's breach history doesn't affect other agents.
+    _first_breach: Dict[str, float] = field(default_factory=dict, repr=False)
 
     def __post_init__(self):
         if not self.label:
             self.label = f"{self.kind.value} > {self.threshold}"
 
-    def reset(self):
-        """Reset sustained breach tracking."""
-        self._first_breach = None
+    def reset(self, agent_id: Optional[str] = None) -> None:
+        """Reset sustained breach tracking.
+
+        If *agent_id* is given, only that agent's tracking is cleared.
+        Otherwise all tracking is cleared (useful for global resets).
+        """
+        if agent_id is not None:
+            self._first_breach.pop(agent_id, None)
+        else:
+            self._first_breach.clear()
 
     def evaluate(self, agent_state: Dict[str, Any], now: Optional[float] = None) -> bool:
         """Check if this trigger fires for the given agent state."""
@@ -137,20 +145,21 @@ class TriggerCondition:
             return False
 
         now = now or time.time()
+        agent_id = agent_state.get("agent_id", "_default")
         breached = self._check_breach(agent_state)
 
         if not breached:
-            self._first_breach = None
+            self._first_breach.pop(agent_id, None)
             return False
 
         if self.sustained_seconds <= 0:
             return True
 
-        if self._first_breach is None:
-            self._first_breach = now
+        if agent_id not in self._first_breach:
+            self._first_breach[agent_id] = now
             return False
 
-        elapsed = now - self._first_breach
+        elapsed = now - self._first_breach[agent_id]
         return elapsed >= self.sustained_seconds
 
     def _check_breach(self, state: Dict[str, Any]) -> bool:
@@ -392,6 +401,8 @@ class KillSwitchManager:
             key_map = {
                 TriggerKind.RESOURCE_CPU: "cpu_percent",
                 TriggerKind.RESOURCE_MEMORY: "memory_mb",
+                TriggerKind.RESOURCE_DISK: "disk_percent",
+                TriggerKind.RESOURCE_NETWORK: "network_mbps",
                 TriggerKind.BEHAVIOR_ANOMALY: "anomaly_score",
                 TriggerKind.TIME_LIMIT: "uptime_seconds",
                 TriggerKind.REQUEST_RATE: "request_rate",
@@ -548,7 +559,7 @@ class KillSwitchManager:
         if current in ("dead", "quarantined", "suspended"):
             self._agent_states[agent_id] = "alive"
             for trigger in self._triggers:
-                trigger.reset()
+                trigger.reset(agent_id=agent_id)
             return True
         return False
 

--- a/tests/test_kill_switch.py
+++ b/tests/test_kill_switch.py
@@ -112,10 +112,18 @@ class TestTriggerCondition(unittest.TestCase):
 
     def test_reset(self):
         t = TriggerCondition(kind=TriggerKind.RESOURCE_CPU, threshold=80.0, sustained_seconds=10)
-        t.evaluate({"cpu_percent": 90}, now=1000.0)
-        self.assertIsNotNone(t._first_breach)
+        t.evaluate({"cpu_percent": 90, "agent_id": "a1"}, now=1000.0)
+        self.assertIn("a1", t._first_breach)
+        t.reset(agent_id="a1")
+        self.assertNotIn("a1", t._first_breach)
+
+    def test_reset_all(self):
+        t = TriggerCondition(kind=TriggerKind.RESOURCE_CPU, threshold=80.0, sustained_seconds=10)
+        t.evaluate({"cpu_percent": 90, "agent_id": "a1"}, now=1000.0)
+        t.evaluate({"cpu_percent": 90, "agent_id": "a2"}, now=1000.0)
+        self.assertEqual(len(t._first_breach), 2)
         t.reset()
-        self.assertIsNone(t._first_breach)
+        self.assertEqual(len(t._first_breach), 0)
 
     def test_exact_threshold(self):
         t = TriggerCondition(kind=TriggerKind.RESOURCE_CPU, threshold=80.0)
@@ -273,6 +281,35 @@ class TestKillSwitchManager(unittest.TestCase):
         # Only fires again after another full sustained period
         result4 = mgr.evaluate(state, now=t0 + 30.0)
         self.assertTrue(result4.should_kill)
+
+    def test_revive_only_resets_target_agent_breach(self):
+        """Reviving agent B must NOT wipe agent A's sustained breach tracking."""
+        trigger = TriggerCondition(
+            kind=TriggerKind.RESOURCE_CPU,
+            threshold=80.0,
+            sustained_seconds=30.0,
+            label="CPU overload",
+        )
+        mgr = KillSwitchManager(cooldown_seconds=0)
+        mgr.add_trigger(trigger)
+        mgr.register_agent("a")
+        mgr.register_agent("b")
+
+        t = 1000.0
+        state_a = {"agent_id": "a", "cpu_percent": 95.0}
+
+        # Agent A breaching for 25 seconds
+        mgr.evaluate(state_a, now=t)
+        mgr.evaluate(state_a, now=t + 25)
+
+        # Agent B gets killed and revived — unrelated to A
+        mgr.kill("b")
+        mgr.revive("b")
+
+        # Agent A should still fire after the full 30s (25s already elapsed + 5 more)
+        result = mgr.evaluate(state_a, now=t + 30)
+        self.assertTrue(result.should_kill,
+                        "Reviving agent B must not reset agent A's sustained breach tracking")
 
     def test_unknown_agent_status(self):
         mgr = self._make_mgr()


### PR DESCRIPTION
## Summary
Fixes a safety-critical bug where evive() reset sustained breach tracking for ALL agents, not just the revived one.

## Changes
- _first_breach is now a Dict[str, float] keyed by agent_id (was Optional[float])
- eset() accepts optional gent_id for targeted resets
- valuate() uses gent_id from agent state for per-agent tracking
- evive() only clears the revived agent's breach timers
- Added missing RESOURCE_DISK/RESOURCE_NETWORK to evaluate proximity key_map
- Added test proving reviving agent B doesn't affect agent A's tracking

## Testing
All 66 tests pass including new multi-agent isolation test.

Closes #60