### PR TITLE
fix: per-agent breach tracking in KillSwitchManager.revive()

### DIFF
--- a/src/replication/kill_switch.py
+++ b/src/replication/kill_switch.py
@@ -120,16 +120,24 @@ class TriggerCondition:
     enabled: bool = True
     custom_fn: Optional[Callable[[Dict[str, Any]], bool]] = None
 
-    # Internal tracking for sustained triggers
-    _first_breach: Optional[float] = field(default=None, repr=False)
+    # Internal tracking for sustained triggers — keyed by agent_id so
+    # that breach windows are independent across agents in fleet mode.
+    _first_breach: Dict[str, float] = field(default_factory=dict, repr=False)
 
     def __post_init__(self):
         if not self.label:
             self.label = f"{self.kind.value} > {self.threshold}"
 
-    def reset(self):
-        """Reset sustained breach tracking."""
-        self._first_breach = None
+    def reset(self, agent_id: Optional[str] = None) -> None:
+        """Reset sustained breach tracking.
+
+        If *agent_id* is given, only that agent's tracking is cleared;
+        otherwise **all** per-agent tracking is cleared (bulk reset).
+        """
+        if agent_id is not None:
+            self._first_breach.pop(agent_id, None)
+        else:
+            self._first_breach.clear()
 
     def evaluate(self, agent_state: Dict[str, Any], now: Optional[float] = None) -> bool:
         """Check if this trigger fires for the given agent state."""
@@ -137,20 +145,21 @@ class TriggerCondition:
             return False
 
         now = now or time.time()
+        agent_id = agent_state.get("agent_id", "_default")
         breached = self._check_breach(agent_state)
 
         if not breached:
-            self._first_breach = None
+            self._first_breach.pop(agent_id, None)
             return False
 
         if self.sustained_seconds <= 0:
             return True
 
-        if self._first_breach is None:
-            self._first_breach = now
+        if agent_id not in self._first_breach:
+            self._first_breach[agent_id] = now
             return False
 
-        elapsed = now - self._first_breach
+        elapsed = now - self._first_breach[agent_id]
         return elapsed >= self.sustained_seconds
 
     def _check_breach(self, state: Dict[str, Any]) -> bool:
@@ -392,6 +401,8 @@ class KillSwitchManager:
             key_map = {
                 TriggerKind.RESOURCE_CPU: "cpu_percent",
                 TriggerKind.RESOURCE_MEMORY: "memory_mb",
+                TriggerKind.RESOURCE_DISK: "disk_percent",
+                TriggerKind.RESOURCE_NETWORK: "network_mbps",
                 TriggerKind.BEHAVIOR_ANOMALY: "anomaly_score",
                 TriggerKind.TIME_LIMIT: "uptime_seconds",
                 TriggerKind.REQUEST_RATE: "request_rate",
@@ -538,8 +549,8 @@ class KillSwitchManager:
     def revive(self, agent_id: str) -> bool:
         """Revive a killed/quarantined/suspended agent. Returns True if state changed.
 
-        Resets all trigger breach tracking so sustained triggers must
-        re-observe the full sustained duration before firing again.
+        Only resets breach tracking for the revived agent so that
+        sustained triggers for *other* agents are not disturbed.
         Without this reset, stale ``_first_breach`` timestamps from
         the previous agent lifecycle would cause sustained triggers
         to fire immediately on the next threshold breach.
@@ -548,7 +559,7 @@ class KillSwitchManager:
         if current in ("dead", "quarantined", "suspended"):
             self._agent_states[agent_id] = "alive"
             for trigger in self._triggers:
-                trigger.reset()
+                trigger.reset(agent_id=agent_id)
             return True
         return False
 

--- a/tests/test_kill_switch.py
+++ b/tests/test_kill_switch.py
@@ -112,10 +112,10 @@ class TestTriggerCondition(unittest.TestCase):
 
     def test_reset(self):
         t = TriggerCondition(kind=TriggerKind.RESOURCE_CPU, threshold=80.0, sustained_seconds=10)
-        t.evaluate({"cpu_percent": 90}, now=1000.0)
-        self.assertIsNotNone(t._first_breach)
+        t.evaluate({"agent_id": "a1", "cpu_percent": 90}, now=1000.0)
+        self.assertTrue(len(t._first_breach) > 0)
         t.reset()
-        self.assertIsNone(t._first_breach)
+        self.assertEqual(len(t._first_breach), 0)
 
     def test_exact_threshold(self):
         t = TriggerCondition(kind=TriggerKind.RESOURCE_CPU, threshold=80.0)
@@ -236,6 +236,39 @@ class TestKillSwitchManager(unittest.TestCase):
         mgr = self._make_mgr()
         mgr.register_agent("a1")
         self.assertFalse(mgr.revive("a1"))
+
+    def test_revive_does_not_reset_other_agents_breach_tracking(self):
+        """Reviving agent B must NOT wipe agent A's sustained breach timer.
+
+        This is the core bug from issue #60: revive() used to call
+        trigger.reset() globally, destroying breach tracking for all agents.
+        """
+        trigger = TriggerCondition(
+            kind=TriggerKind.RESOURCE_CPU,
+            threshold=80.0,
+            sustained_seconds=30.0,
+            label="CPU overload",
+        )
+        mgr = KillSwitchManager(cooldown_seconds=0)
+        mgr.add_trigger(trigger)
+        mgr.register_agent("a")
+        mgr.register_agent("b")
+
+        state_a = {"agent_id": "a", "cpu_percent": 95.0}
+
+        # Agent A has been breaching for 25 seconds
+        t = 1000.0
+        mgr.evaluate(state_a, now=t)          # starts timer
+        mgr.evaluate(state_a, now=t + 25)     # 25s elapsed, 5s remaining
+
+        # Agent B gets killed and revived — totally unrelated
+        mgr.kill("b")
+        mgr.revive("b")
+
+        # Agent A's tracking must survive — should fire at t+30
+        result = mgr.evaluate(state_a, now=t + 30)
+        self.assertTrue(result.should_kill,
+                        "Agent A's sustained breach tracking was destroyed by reviving agent B")
 
     def test_revive_resets_trigger_breach_state(self):
         """After revive, sustained triggers must re-observe the full duration."""
@@ -405,6 +438,23 @@ class TestKillSwitchManager(unittest.TestCase):
         result = mgr.evaluate({"agent_id": "a1", "cpu_percent": 60, "anomaly_score": 0.35})
         self.assertIn("CPU high", result.scores)
         self.assertAlmostEqual(result.scores["CPU high"], 60.0 / 80.0)
+
+    def test_disk_network_proximity_scores(self):
+        """RESOURCE_DISK and RESOURCE_NETWORK triggers must report proximity scores."""
+        mgr = KillSwitchManager()
+        mgr.add_trigger(TriggerCondition(
+            kind=TriggerKind.RESOURCE_DISK, threshold=90.0, label="Disk high",
+        ))
+        mgr.add_trigger(TriggerCondition(
+            kind=TriggerKind.RESOURCE_NETWORK, threshold=100.0, label="Net high",
+        ))
+        result = mgr.evaluate({
+            "agent_id": "x", "disk_percent": 45.0, "network_mbps": 50.0,
+        })
+        self.assertIn("Disk high", result.scores)
+        self.assertAlmostEqual(result.scores["Disk high"], 45.0 / 90.0)
+        self.assertIn("Net high", result.scores)
+        self.assertAlmostEqual(result.scores["Net high"], 50.0 / 100.0)
 
     def test_kill_event_to_dict(self):
         e = KillEvent(


### PR DESCRIPTION
## Summary

**Safety-critical fix**: evive() was resetting sustained breach tracking for ALL agents globally, not just the revived one. This could prevent legitimate kills in multi-agent deployments.

## Changes

- **TriggerCondition._first_breach**: Changed from Optional[float] to Dict[str, float] keyed by agent_id
- **TriggerCondition.reset()**: Now accepts optional gent_id parameter — clears only that agent's tracking when specified, or all tracking when called without args
- **TriggerCondition.evaluate()**: Uses gent_state['agent_id'] to key breach timestamps per-agent
- **KillSwitchManager.revive()**: Passes gent_id to 	rigger.reset() so only the revived agent's tracking is cleared
- **Secondary fix**: Added RESOURCE_DISK and RESOURCE_NETWORK to the proximity scores key_map in valuate() (was missing, causing disk/network triggers to not report proximity scores)

## Testing

- All 66 existing tests pass (updated 	est_reset for new dict-based tracking)
- Added 	est_revive_does_not_reset_other_agents to verify multi-agent isolation

Fixes #60