### PR TITLE
fix(fleet): use real RegistryEntry dataclass in demo fleet

### DIFF
--- a/src/replication/fleet.py
+++ b/src/replication/fleet.py
@@ -24,7 +24,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Sequence
 
 from .contract import ReplicationContract
-from .controller import Controller
+from .controller import Controller, RegistryEntry
 
 
 # ── data model ───────────────────────────────────────────────────────
@@ -297,9 +297,7 @@ def _build_demo_fleet() -> tuple:
             signature="",
         )
         manifest = controller.sign_manifest(manifest)
-        controller.registry[wid] = type(
-            "RegistryEntry", (), {"manifest": manifest, "last_heartbeat": now}
-        )()
+        controller.registry[wid] = RegistryEntry(manifest=manifest, last_heartbeat=now)
 
     # Quarantine one worker for demo
     controller._quarantined.add("gen2-d005")


### PR DESCRIPTION
## Problem

\_build_demo_fleet()\ in \leet.py\ was creating anonymous objects via \	ype('RegistryEntry', (), {...})()\ instead of using the actual \RegistryEntry\ dataclass from \controller.py\.

This means:
- \isinstance(entry, RegistryEntry)\ returns \False\ for demo entries
- Dataclass introspection (\ields()\, \sdict()\) fails
- Any future \RegistryEntry\ methods won't be available on demo entries

## Fix

Import and use the real \RegistryEntry\ dataclass directly.