### PR TITLE
ci: add docs build check for PRs

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -1,0 +1,49 @@
+name: Docs Build Check
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'src/**'
+
+permissions:
+  contents: read
+
+jobs:
+  docs-check:
+    name: Verify Docs Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          pip install mkdocs-material mkdocstrings[python] pymdown-extensions
+          pip install -e ".[dev]"
+
+      - name: Build docs (strict mode)
+        run: mkdocs build --strict
+
+      - name: Check for broken links
+        run: |
+          # Verify all nav entries reference existing files
+          echo "Checking nav references..."
+          ERRORS=0
+          for f in $(grep -oP '(?<=: )\S+\.md' mkdocs.yml); do
+            if [ ! -f "docs/$f" ]; then
+              echo "::error::Missing docs file: docs/$f (referenced in mkdocs.yml nav)"
+              ERRORS=$((ERRORS + 1))
+            fi
+          done
+          if [ "$ERRORS" -gt 0 ]; then
+            echo "::error::Found $ERRORS missing doc files"
+            exit 1
+          fi
+          echo "✅ All nav references valid"


### PR DESCRIPTION
## Changes
- Adds a new workflow that runs on PRs touching docs/, mkdocs.yml, or src/
- Builds docs with mkdocs --strict to catch warnings as errors
- Validates all mkdocs.yml nav entries reference existing files
- Prevents broken documentation from being merged