### PR TITLE
refactor(fleet): use public Controller API instead of private _quarantined

### DIFF
--- a/src/replication/fleet.py
+++ b/src/replication/fleet.py
@@ -88,7 +88,7 @@ def snapshot_fleet(controller: Controller) -> List[WorkerSnapshot]:
             expired = age > controller.contract.expiration_seconds
 
         # Check quarantine
-        quarantined = wid in controller._quarantined
+        quarantined = controller.is_quarantined(wid)
 
         # Verify signature
         try:
@@ -299,7 +299,7 @@ def _build_demo_fleet() -> tuple:
         controller.registry[wid] = RegistryEntry(manifest=manifest, last_heartbeat=now)
 
     # Quarantine one worker for demo
-    controller._quarantined.add("gen2-d005")
+    controller.mark_quarantined("gen2-d005")
 
     return controller, contract
 


### PR DESCRIPTION
## What

Fixes encapsulation violations in leet.py where it directly accessed controller._quarantined (a private set) instead of using the public API.

## Changes

- snapshot_fleet(): Use controller.is_quarantined(wid) instead of wid in controller._quarantined
- _build_demo_fleet(): Use controller.mark_quarantined() instead of controller._quarantined.add() — this also gains an audit log entry for demo quarantine actions

## Why

The Controller class provides is_quarantined() and mark_quarantined() as public methods specifically for this purpose. Accessing the private _quarantined set directly:
- Bypasses audit logging (mark_quarantined logs, direct add doesn't)
- Creates coupling to internal implementation details
- Would break if quarantine storage changes (e.g., moved to a database)

All 48 fleet tests pass.