### PR TITLE
fix(dlp): tighten AWS_SECRET regex to reduce false positives

### DIFF
--- a/src/replication/dlp_scanner.py
+++ b/src/replication/dlp_scanner.py
@@ -132,7 +132,9 @@ _BUILTIN_PATTERNS: List[Tuple[str, str, Category, Severity, str]] = [
     # Secrets / API keys
     ("AWS_KEY", r"\bAKIA[0-9A-Z]{16}\b",
      Category.SECRET, Severity.CRITICAL, "[AWS_KEY]"),
-    ("AWS_SECRET", r"\b[A-Za-z0-9/+=]{40}\b",
+    ("AWS_SECRET",
+     r"(?i)(?:aws.{0,20})?(?:secret.?(?:access)?.?key|secret_key|aws_secret)"
+     r"\s*[:=]\s*['\"]?([A-Za-z0-9/+=]{40})['\"]?",
      Category.SECRET, Severity.CRITICAL, "[AWS_SECRET]"),
     ("OPENAI_KEY", r"\bsk-[A-Za-z0-9]{20,}\b",
      Category.SECRET, Severity.CRITICAL, "[API_KEY]"),


### PR DESCRIPTION
## Problem
The AWS_SECRET pattern matched **any** 40-character base64-like string — SHA256 hashes, random IDs, etc. Excessive false positives desensitize operators to real findings.

## Fix
Require a contextual prefix (secret_key, aws_secret, etc.) so it only fires in credential assignment context.

## Testing
All 3872 existing tests pass.